### PR TITLE
Flickerfix mostly

### DIFF
--- a/media_kit_core_video/windows/CMakeLists.txt
+++ b/media_kit_core_video/windows/CMakeLists.txt
@@ -90,6 +90,20 @@ if(NOT EXISTS "${ANGLE_SRC}")
   )
 endif()
 
+# Some GPUs/Hardware seem to experience black flickering when rendering with hardware acceleration.
+# Calling |glFinish| eliminates this. This seems to be some sort of synchronization problem between Flutter / Monitor / mpv etc.
+# Now there are bunch of |glFinish| calls inside |ANGLESurfaceManager| & |VideoOutput| classes which fix any flickering issues.
+# There doesn't seem to be any better alternative for OpenGL ES 2.0. See:
+#
+# * https://github.com/alexmercerind/media_kit/issues/10
+# * https://github.com/alexmercerind/media_kit/pull/11
+# * https://stackoverflow.com/a/12157120/12825435
+#
+# Though |glFinish| is not optimal, it is still way-way better in terms of performance as compared to software rendering.
+# Personally, my budget machine with AMD Ryzen 3 2200U with integrated Radeon Vega 3 Mobile Graphics never experienced this issue.
+# At most, 4K 30FPS or 1080p 60FPS videos play flawlessly without any major load on the hardware. 4K 60FPS videos certainly experience some frame drops. But nothing that can be referred as flicker.
+add_definitions(-DENABLE_GL_FINISH_SAFEGUARD)
+
 # Add libmpv & ANGLE headers to the include path.
 include_directories(
   "${LIBMPV_SRC}/include"

--- a/media_kit_core_video/windows/angle_surface_manager.cc
+++ b/media_kit_core_video/windows/angle_surface_manager.cc
@@ -61,7 +61,7 @@ void ANGLESurfaceManager::MakeCurrent(bool value) {
     eglMakeCurrent(display_, surface_, surface_, context_);
   } else {
     glFinish();
-    eglMakeCurrent(display_, surface_, surface_, context_);
+    eglMakeCurrent(display_, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
   }
 }
 

--- a/media_kit_core_video/windows/angle_surface_manager.cc
+++ b/media_kit_core_video/windows/angle_surface_manager.cc
@@ -61,7 +61,7 @@ void ANGLESurfaceManager::MakeCurrent(bool value) {
     eglMakeCurrent(display_, surface_, surface_, context_);
   } else {
     glFinish();
-    eglMakeCurrent(display_, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+    eglMakeCurrent(EGL_NO_DISPLAY, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
   }
 }
 

--- a/media_kit_core_video/windows/angle_surface_manager.cc
+++ b/media_kit_core_video/windows/angle_surface_manager.cc
@@ -43,7 +43,6 @@ HANDLE ANGLESurfaceManager::HandleResize(int32_t width, int32_t height) {
   }
   width_ = width;
   height_ = height;
-  glFinish();
   // Create new Direct3D texture & |surface_| preserving previously created
   // |display_| & |context_| from the constructor.
   Initialize();
@@ -57,11 +56,16 @@ void ANGLESurfaceManager::SwapBuffers() {
 
 void ANGLESurfaceManager::MakeCurrent(bool value) {
   if (value) {
+#ifdef ENABLE_GL_FINISH_SAFEGUARD
     glFinish();
+#endif
     eglMakeCurrent(display_, surface_, surface_, context_);
   } else {
+#ifdef ENABLE_GL_FINISH_SAFEGUARD
     glFinish();
-    eglMakeCurrent(EGL_NO_DISPLAY, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+#endif
+    eglMakeCurrent(EGL_NO_DISPLAY, EGL_NO_SURFACE, EGL_NO_SURFACE,
+                   EGL_NO_CONTEXT);
   }
 }
 
@@ -271,7 +275,9 @@ void ANGLESurfaceManager::CleanUp(bool release_context) {
   } else {
     // Clear context & destroy existing |surface_|.
     eglMakeCurrent(display_, EGL_NO_SURFACE, EGL_NO_SURFACE, context_);
+#ifdef ENABLE_GL_FINISH_SAFEGUARD
     glFinish();
+#endif
     if (display_ != EGL_NO_DISPLAY && surface_ != EGL_NO_SURFACE) {
       eglDestroySurface(display_, surface_);
     }

--- a/media_kit_core_video/windows/angle_surface_manager.cc
+++ b/media_kit_core_video/windows/angle_surface_manager.cc
@@ -43,6 +43,7 @@ HANDLE ANGLESurfaceManager::HandleResize(int32_t width, int32_t height) {
   }
   width_ = width;
   height_ = height;
+  glFinish();
   // Create new Direct3D texture & |surface_| preserving previously created
   // |display_| & |context_| from the constructor.
   Initialize();
@@ -56,9 +57,11 @@ void ANGLESurfaceManager::SwapBuffers() {
 
 void ANGLESurfaceManager::MakeCurrent(bool value) {
   if (value) {
+    glFinish();
     eglMakeCurrent(display_, surface_, surface_, context_);
   } else {
-    eglMakeCurrent(display_, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+    glFinish();
+    eglMakeCurrent(display_, surface_, surface_, context_);
   }
 }
 
@@ -268,6 +271,7 @@ void ANGLESurfaceManager::CleanUp(bool release_context) {
   } else {
     // Clear context & destroy existing |surface_|.
     eglMakeCurrent(display_, EGL_NO_SURFACE, EGL_NO_SURFACE, context_);
+    glFinish();
     if (display_ != EGL_NO_DISPLAY && surface_ != EGL_NO_SURFACE) {
       eglDestroySurface(display_, surface_);
     }

--- a/media_kit_core_video/windows/video_output.cc
+++ b/media_kit_core_video/windows/video_output.cc
@@ -144,17 +144,9 @@ void VideoOutput::Render() {
         {MPV_RENDER_PARAM_INVALID, nullptr},
     };
     mpv_render_context_render(render_context_, params);
-    // Some GPUs/Hardware seem to cause black flickering when rendering with
-    // hardware acceleration. Calling |glFinish| eliminates this. This seems to
-    // be some sort of synchronization problem between Flutter / Monitor / mpv
-    // etc. This method is invoked directly on the Flutter's render thread, so I
-    // don't think there's anything better that can be done.
-    //
-    // Personally, my budget machine with AMD Ryzen 3 2200U with integrated
-    // Radeon Vega 3 Mobile Graphics never experienced this issue.
-    // At most, 4K 30FPS or 1080p 60FPS videos play flawlessly without any major
-    // load on the hardware. 4K 60FPS videos certainly experience frame drops.
+#ifdef ENABLE_GL_FINISH_SAFEGUARD
     glFinish();
+#endif
     surface_manager_->MakeCurrent(false);
   }
   // S/W


### PR DESCRIPTION
so turns out the brute force way can be the best way, the fixes 99% of flickers, to the degree that loading an 8k video with an gpu stress test running in the foreground is, while still not watchable, not flickering at all... mostly 

every now and then there is a rare flicker, however im fairly convinced that this is because of skia itself, as other elements of the app become troublesome anyways, like animations freezing. and I really don't think there is anything we can do with that.

this MIGHT be troublesome due to the extra glfinishes. meaning high refreshrate content might suffer from this, however I don't have a display to test that with unfortunately.

also fixes resize flicker that I was experiencing. 

all in all, 4k60 content is now flicker free

hopefully Addresses #10 