### PR TITLE
perf(win): use ThreadPool for video rendering & EGL/ANGLE usage synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,13 +423,11 @@ classDiagram
   }
 
   class VideoOutputManager {
-    +Create(handle: int, width: optional<int>, height: optional<int>)
+    +Create(handle: int, width: optional<int>, height: optional<int>, texture_update_callback: std::function)
     +Dispose(handle: int)
 
-    -std::mutex mutex_
     -std::mutex render_mutex_
     -flutter::PluginRegistrarWindows registrar_
-    -std::unique_ptr<MethodChannel> channel_
     -std::unordered_map<int64_t, std::unique_ptr<VideoOutput>> video_outputs_
   }
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ dependencies:
 ## Platforms
 
 | Platform | Audio | Video |
-|----------|-------|-------|
+| -------- | ----- | ----- |
 | Windows  | Ready | Ready |
 | Linux    | Ready | WIP   |
 | macOS    | WIP   | WIP   |
@@ -412,7 +412,7 @@ classDiagram
 
   MediaKitVideoPlugin "1" *-- "1" VideoOutputManager: Create VideoOutput(s) with VideoOutputManager for handle passed through platform channel
   VideoOutputManager "1" *-- "*" VideoOutput
-  VideoOutputManager "1" *-- "1" ThreadPool: 
+  VideoOutputManager "1" *-- "1" ThreadPool:
   VideoOutput "1" o-- "1" ThreadPool: Post creation, resize & render etc. tasks involving EGL to ensure synchronous EGL/ANGLE usage across multiple VideoOutput(s)
   VideoOutput "1" *-- "1" ANGLESurfaceManager: Only for H/W accelerated rendering
 
@@ -422,7 +422,7 @@ classDiagram
     -std::unique_ptr<VideoOutputManager> video_output_manager_
     -HandleMethodCall(method_call, result);
   }
-  
+
   class ThreadPool {
     +Post(function: std::function)
   }
@@ -430,8 +430,8 @@ classDiagram
   class VideoOutputManager {
     +Create(handle: int, width: optional<int>, height: optional<int>, texture_update_callback: std::function)
     +Dispose(handle: int)
-    
-    -std::mutex mutex
+
+    -std::mutex mutex_
     -std::unique_ptr<ThreadPool> thread_pool_
     -flutter::PluginRegistrarWindows registrar_
     -std::unordered_map<int64_t, std::unique_ptr<VideoOutput>> video_outputs_
@@ -451,7 +451,6 @@ classDiagram
     -std::unordered_map<int64_t, std::unique_ptr<FlutterDesktopGpuSurfaceDescriptor>> textures_ HW
     -std::unique_ptr<uint8_t[]> pixel_buffer_ SW
     -std::unordered_map<int64_t, std::unique_ptr<FlutterDesktopPixelBuffer>> pixel_buffer_textures_ SW
-    -std::mutex mutex_
     -std::function texture_update_callback_
 
     +SetTextureUpdateCallback(callback: std::function<void(int64_t, int64_t, int64_t)>)
@@ -528,13 +527,12 @@ This hardware accelerated video output requires DirectX 11 or higher. Most Windo
 
 <summary> Windows 7 & 8.x also seem to be working correctly. </summary>
 
-<br></br>  
+<br></br>
 
 ![0](https://user-images.githubusercontent.com/28951144/212947036-4a2430d6-729e-47d7-a356-c8cc8534a1aa.jpg)
 ![1](https://user-images.githubusercontent.com/28951144/212947046-cc8d441c-96f8-4437-9f59-b4613ca73f2a.jpg)
 
 </details>
-
 
 You can visit my [experimentation repository](https://github.com/alexmercerind/flutter-windows-ANGLE-OpenGL-Direct3D-Interop) to see a minimal example showing OpenGL ES rendering inside Flutter Windows.
 

--- a/media_kit_test/lib/main.dart
+++ b/media_kit_test/lib/main.dart
@@ -741,37 +741,18 @@ class _MultiplePlayersMultipleVideosScreenState
 
   @override
   Widget build(BuildContext context) {
-    final horizontal = MediaQuery.of(context).size.width / 2 >
-        MediaQuery.of(context).size.height;
+    final horizontal =
+        MediaQuery.of(context).size.width > MediaQuery.of(context).size.height;
     return Scaffold(
       appBar: AppBar(
         title: const Text('package:media_kit'),
       ),
-      body: Row(
-        children: [
-          for (int i = 0; i < 2; i++)
-            Expanded(
-              child: horizontal
-                  ? Row(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        Expanded(
-                          flex: 3,
-                          child: Container(
-                            alignment: Alignment.center,
-                            child: getVideoForIndex(i),
-                          ),
-                        ),
-                        const VerticalDivider(width: 1.0, thickness: 1.0),
-                        Expanded(
-                          flex: 1,
-                          child: ListView(
-                            children: [...getAssetsListForIndex(i)],
-                          ),
-                        ),
-                      ],
-                    )
-                  : ListView(
+      body: horizontal
+          ? Row(
+              children: [
+                for (int i = 0; i < 2; i++)
+                  Expanded(
+                    child: ListView(
                       children: [
                         Container(
                           alignment: Alignment.center,
@@ -786,9 +767,24 @@ class _MultiplePlayersMultipleVideosScreenState
                         ...getAssetsListForIndex(i),
                       ],
                     ),
+                  ),
+              ],
+            )
+          : ListView(
+              children: [
+                for (int i = 0; i < 2; i++) ...[
+                  Container(
+                    alignment: Alignment.center,
+                    width: (MediaQuery.of(context).size.width - 64.0),
+                    height:
+                        (MediaQuery.of(context).size.width - 64.0) * 9.0 / 16.0,
+                    child: getVideoForIndex(i),
+                  ),
+                  const Divider(height: 1.0, thickness: 1.0),
+                  ...getAssetsListForIndex(i),
+                ]
+              ],
             ),
-        ],
-      ),
     );
   }
 }
@@ -913,12 +909,12 @@ class _StressTestScreenState extends State<StressTestScreen> {
           controllers.add(controller);
         }
         for (int i = 0; i < count; i++) {
-          players[i].volume = 0.0;
           await players[i].open(
             Playlist([Media('asset://assets/video_${i % 5}.mp4')]),
             play: true,
           );
           await players[i].setPlaylistMode(PlaylistMode.loop);
+          players[i].volume = 0.0;
         }
         setState(() {});
       },
@@ -940,26 +936,44 @@ class _StressTestScreenState extends State<StressTestScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final children = controllers
+        .map(
+          (e) => Card(
+            elevation: 4.0,
+            margin: EdgeInsets.zero,
+            clipBehavior: Clip.antiAlias,
+            child: Video(controller: e),
+          ),
+        )
+        .toList();
     return Scaffold(
       appBar: AppBar(
         title: const Text('package:media_kit'),
       ),
-      body: GridView.count(
-        crossAxisCount: 2,
-        padding: const EdgeInsets.all(16.0),
-        mainAxisSpacing: 16.0,
-        crossAxisSpacing: 16.0,
-        childAspectRatio: 16.0 / 9.0,
-        children: controllers
-            .map(
-              (e) => Card(
-                elevation: 4.0,
-                clipBehavior: Clip.antiAlias,
-                child: Video(controller: e),
-              ),
+      body: MediaQuery.of(context).size.width >
+              MediaQuery.of(context).size.height
+          ? GridView.count(
+              crossAxisCount: 2,
+              padding: const EdgeInsets.all(16.0),
+              mainAxisSpacing: 16.0,
+              crossAxisSpacing: 16.0,
+              childAspectRatio: 16.0 / 9.0,
+              children: children,
             )
-            .toList(),
-      ),
+          : ListView(
+              padding: const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 0.0),
+              children: children
+                  .map(
+                    (e) => Container(
+                      padding: const EdgeInsets.only(bottom: 16.0),
+                      width: MediaQuery.of(context).size.width - 32.0,
+                      height:
+                          9 / 16.0 * (MediaQuery.of(context).size.width - 32.0),
+                      child: e,
+                    ),
+                  )
+                  .toList(),
+            ),
     );
   }
 }

--- a/media_kit_video/lib/src/video.dart
+++ b/media_kit_video/lib/src/video.dart
@@ -142,7 +142,7 @@ class _VideoState extends State<Video> {
                                 // EGLDisplay, EGLSurface etc. (depending upon platform) are also changed.
                                 // Just don't show that 1 pixel texture to the UI.
                                 // NOTE: Unmounting |Texture| causes the |MarkTextureFrameAvailable| to not do anything.
-                                if (rect.width == 1.0 && rect.height == 1.0)
+                                if (rect.width <= 1.0 && rect.height <= 1.0)
                                   Positioned.fill(
                                     child: Container(
                                       color: widget.fill,

--- a/media_kit_video/lib/src/video_controller.dart
+++ b/media_kit_video/lib/src/video_controller.dart
@@ -79,6 +79,7 @@ class VideoController {
       height,
     );
     // Invoking native implementation for querying video adapter, registering OpenGL/Direct3D/ANGLE/pixel-buffer output callbacks & Flutter texture.
+    // NOTE: Sending `int64_t` is causing crash on Windows 7, so sending as string.
     final result = await _channel.invokeMethod(
       'VideoOutputManager.Create',
       {
@@ -88,11 +89,11 @@ class VideoController {
       },
     );
     // Notify about updated texture ID & [Rect].
-    final Rect rect = Rect.fromLTRB(
+    final Rect rect = Rect.fromLTWH(
       result['rect']['left'] * 1.0,
       result['rect']['top'] * 1.0,
-      result['rect']['right'] * 1.0,
-      result['rect']['bottom'] * 1.0,
+      result['rect']['width'] * 1.0,
+      result['rect']['height'] * 1.0,
     );
     final int id = result['id'];
     controller.rect.value = rect;
@@ -105,6 +106,7 @@ class VideoController {
   /// Releases the allocated resources back to the system.
   Future<void> dispose() {
     _controllers.remove(handle);
+    // NOTE: Sending `int64_t` is causing crash on Windows 7, so sending as string.
     return _channel.invokeMethod(
       'VideoOutputManager.Dispose',
       {
@@ -130,11 +132,11 @@ final _channel = const MethodChannel('com.alexmercerind/media_kit_video')
           {
             // Notify about updated texture ID & [Rect].
             final int handle = call.arguments['handle'];
-            final Rect rect = Rect.fromLTRB(
+            final Rect rect = Rect.fromLTWH(
               call.arguments['rect']['left'] * 1.0,
               call.arguments['rect']['top'] * 1.0,
-              call.arguments['rect']['right'] * 1.0,
-              call.arguments['rect']['bottom'] * 1.0,
+              call.arguments['rect']['width'] * 1.0,
+              call.arguments['rect']['height'] * 1.0,
             );
             final int id = call.arguments['id'];
             _controllers[handle]?.rect.value = rect;

--- a/media_kit_video/lib/src/video_controller.dart
+++ b/media_kit_video/lib/src/video_controller.dart
@@ -78,9 +78,23 @@ class VideoController {
       width,
       height,
     );
+
+    // Wait until first texture ID is received i.e. render context & EGL/D3D surface is created.
+    // We are not waiting on the native-side itself because it will block the UI thread.
+    // Background platform channels are not a thing yet.
+    final completer = Completer<void>();
+    void listener() {
+      if (controller.id.value != null) {
+        debugPrint('VideoController: Texture ID: ${controller.id.value}');
+        completer.complete();
+      }
+    }
+
+    controller.id.addListener(listener);
+
     // Invoking native implementation for querying video adapter, registering OpenGL/Direct3D/ANGLE/pixel-buffer output callbacks & Flutter texture.
     // NOTE: Sending `int64_t` is causing crash on Windows 7, so sending as string.
-    final result = await _channel.invokeMethod(
+    await _channel.invokeMethod(
       'VideoOutputManager.Create',
       {
         'handle': controller.handle.toString(),
@@ -88,16 +102,10 @@ class VideoController {
         'height': controller.height.toString(),
       },
     );
-    // Notify about updated texture ID & [Rect].
-    final Rect rect = Rect.fromLTWH(
-      result['rect']['left'] * 1.0,
-      result['rect']['top'] * 1.0,
-      result['rect']['width'] * 1.0,
-      result['rect']['height'] * 1.0,
-    );
-    final int id = result['id'];
-    controller.rect.value = rect;
-    controller.id.value = id;
+
+    await completer.future;
+    controller.id.removeListener(listener);
+
     // Return the [VideoController].
     return controller;
   }
@@ -125,28 +133,33 @@ class VideoController {
 final _channel = const MethodChannel('com.alexmercerind/media_kit_video')
   ..setMethodCallHandler(
     (MethodCall call) async {
-      debugPrint(call.method.toString());
-      debugPrint(call.arguments.toString());
-      switch (call.method) {
-        case 'VideoOutput.Resize':
-          {
-            // Notify about updated texture ID & [Rect].
-            final int handle = call.arguments['handle'];
-            final Rect rect = Rect.fromLTWH(
-              call.arguments['rect']['left'] * 1.0,
-              call.arguments['rect']['top'] * 1.0,
-              call.arguments['rect']['width'] * 1.0,
-              call.arguments['rect']['height'] * 1.0,
-            );
-            final int id = call.arguments['id'];
-            _controllers[handle]?.rect.value = rect;
-            _controllers[handle]?.id.value = id;
-            break;
-          }
-        default:
-          {
-            break;
-          }
+      try {
+        debugPrint(call.method.toString());
+        debugPrint(call.arguments.toString());
+        switch (call.method) {
+          case 'VideoOutput.Resize':
+            {
+              // Notify about updated texture ID & [Rect].
+              final int handle = call.arguments['handle'];
+              final Rect rect = Rect.fromLTWH(
+                call.arguments['rect']['left'] * 1.0,
+                call.arguments['rect']['top'] * 1.0,
+                call.arguments['rect']['width'] * 1.0,
+                call.arguments['rect']['height'] * 1.0,
+              );
+              final int id = call.arguments['id'];
+              _controllers[handle]?.rect.value = rect;
+              _controllers[handle]?.id.value = id;
+              break;
+            }
+          default:
+            {
+              break;
+            }
+        }
+      } catch (exception, stacktrace) {
+        debugPrint(exception.toString());
+        debugPrint(stacktrace.toString());
       }
     },
   );

--- a/media_kit_video/windows/angle_surface_manager.cc
+++ b/media_kit_video/windows/angle_surface_manager.cc
@@ -48,8 +48,9 @@ HANDLE ANGLESurfaceManager::HandleResize(int32_t width, int32_t height) {
 }
 
 void ANGLESurfaceManager::SwapBuffers() {
-  // No need to flush.
-  eglSwapBuffers(display_, surface_);
+#ifdef ENABLE_GL_FINISH_SAFEGUARD
+  glFinish();
+#endif
 }
 
 void ANGLESurfaceManager::MakeCurrent(bool value) {

--- a/media_kit_video/windows/media_kit_video_plugin.cc
+++ b/media_kit_video/windows/media_kit_video_plugin.cc
@@ -50,7 +50,7 @@ void MediaKitVideoPlugin::HandleMethodCall(
       width_value = static_cast<int64_t>(strtoll(width.c_str(), nullptr, 10));
       height_value = static_cast<int64_t>(strtoll(height.c_str(), nullptr, 10));
     }
-    auto video_output = video_output_manager_->Create(
+    video_output_manager_->Create(
         handle_value, width_value, height_value,
         [channel_ptr = channel_.get(), handle = handle_value](
             auto id, auto width, auto height) {
@@ -89,37 +89,7 @@ void MediaKitVideoPlugin::HandleMethodCall(
               }),
               nullptr);
         });
-    result->Success(flutter::EncodableValue(flutter::EncodableMap{
-        {
-            flutter::EncodableValue("handle"),
-            flutter::EncodableValue(handle),
-        },
-        {
-            flutter::EncodableValue("id"),
-            flutter::EncodableValue(video_output->texture_id()),
-        },
-        {
-            flutter::EncodableValue("rect"),
-            flutter::EncodableValue(flutter::EncodableMap{
-                {
-                    flutter::EncodableValue("left"),
-                    flutter::EncodableValue(0),
-                },
-                {
-                    flutter::EncodableValue("top"),
-                    flutter::EncodableValue(0),
-                },
-                {
-                    flutter::EncodableValue("width"),
-                    flutter::EncodableValue(video_output->width()),
-                },
-                {
-                    flutter::EncodableValue("height"),
-                    flutter::EncodableValue(video_output->height()),
-                },
-            }),
-        },
-    }));
+    result->Success(flutter::EncodableValue(std::monostate{}));
   } else if (method_call.method_name().compare("VideoOutputManager.Dispose") ==
              0) {
     auto arguments = std::get<flutter::EncodableMap>(*method_call.arguments());

--- a/media_kit_video/windows/media_kit_video_plugin.cc
+++ b/media_kit_video/windows/media_kit_video_plugin.cc
@@ -19,15 +19,14 @@ void MediaKitVideoPlugin::RegisterWithRegistrar(
 
 MediaKitVideoPlugin::MediaKitVideoPlugin(
     flutter::PluginRegistrarWindows* registrar)
-    : registrar_(registrar) {
+    : registrar_(registrar),
+      video_output_manager_(std::make_unique<VideoOutputManager>(registrar)) {
   channel_ = std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
       registrar->messenger(), "com.alexmercerind/media_kit_video",
       &flutter::StandardMethodCodec::GetInstance());
   channel_->SetMethodCallHandler([&](const auto& call, auto result) {
     HandleMethodCall(call, std::move(result));
   });
-  video_output_manager_ =
-      std::make_unique<VideoOutputManager>(registrar, channel_.get());
 }
 
 MediaKitVideoPlugin::~MediaKitVideoPlugin() {}
@@ -35,11 +34,14 @@ MediaKitVideoPlugin::~MediaKitVideoPlugin() {}
 void MediaKitVideoPlugin::HandleMethodCall(
     const flutter::MethodCall<flutter::EncodableValue>& method_call,
     std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
-  if (IS_METHOD("VideoOutputManager.Create")) {
+  if (method_call.method_name().compare("VideoOutputManager.Create") == 0) {
     auto arguments = std::get<flutter::EncodableMap>(*method_call.arguments());
-    auto handle = std::get<std::string>(arguments[VALUE("handle")]);
-    auto width = std::get<std::string>(arguments[VALUE("width")]);
-    auto height = std::get<std::string>(arguments[VALUE("height")]);
+    auto handle =
+        std::get<std::string>(arguments[flutter::EncodableValue("handle")]);
+    auto width =
+        std::get<std::string>(arguments[flutter::EncodableValue("width")]);
+    auto height =
+        std::get<std::string>(arguments[flutter::EncodableValue("height")]);
     auto handle_value =
         static_cast<int64_t>(strtoll(handle.c_str(), nullptr, 10));
     auto width_value = std::optional<int64_t>{};
@@ -48,43 +50,85 @@ void MediaKitVideoPlugin::HandleMethodCall(
       width_value = static_cast<int64_t>(strtoll(width.c_str(), nullptr, 10));
       height_value = static_cast<int64_t>(strtoll(height.c_str(), nullptr, 10));
     }
-    auto video_output =
-        video_output_manager_->Create(handle_value, width_value, height_value);
-    result->Success(VALUE(flutter::EncodableMap({
+    auto video_output = video_output_manager_->Create(
+        handle_value, width_value, height_value,
+        [channel_ptr = channel_.get(), handle = handle_value](
+            auto id, auto width, auto height) {
+          channel_ptr->InvokeMethod(
+              "VideoOutput.Resize",
+              std::make_unique<flutter::EncodableValue>(flutter::EncodableMap{
+                  {
+                      flutter::EncodableValue("handle"),
+                      flutter::EncodableValue(handle),
+                  },
+                  {
+                      flutter::EncodableValue("id"),
+                      flutter::EncodableValue(id),
+                  },
+                  {
+                      flutter::EncodableValue("rect"),
+                      flutter::EncodableValue(flutter::EncodableMap{
+                          {
+                              flutter::EncodableValue("left"),
+                              flutter::EncodableValue(0),
+                          },
+                          {
+                              flutter::EncodableValue("top"),
+                              flutter::EncodableValue(0),
+                          },
+                          {
+                              flutter::EncodableValue("width"),
+                              flutter::EncodableValue(width),
+                          },
+                          {
+                              flutter::EncodableValue("height"),
+                              flutter::EncodableValue(height),
+                          },
+                      }),
+                  },
+              }),
+              nullptr);
+        });
+    result->Success(flutter::EncodableValue(flutter::EncodableMap{
         {
-            VALUE("id"),
-            VALUE(video_output->texture_id()),
+            flutter::EncodableValue("handle"),
+            flutter::EncodableValue(handle),
         },
         {
-            VALUE("rect"),
-            VALUE(flutter::EncodableMap({
-                {
-                    VALUE("left"),
-                    VALUE(0),
-                },
-                {
-                    VALUE("top"),
-                    VALUE(0),
-                },
-                {
-                    VALUE("right"),
-                    VALUE(video_output->width()),
-                },
-                {
-                    VALUE("bottom"),
-                    VALUE(video_output->height()),
-                },
-            })),
+            flutter::EncodableValue("id"),
+            flutter::EncodableValue(video_output->texture_id()),
         },
-
-    })));
-  } else if (IS_METHOD("VideoOutputManager.Dispose")) {
+        {
+            flutter::EncodableValue("rect"),
+            flutter::EncodableValue(flutter::EncodableMap{
+                {
+                    flutter::EncodableValue("left"),
+                    flutter::EncodableValue(0),
+                },
+                {
+                    flutter::EncodableValue("top"),
+                    flutter::EncodableValue(0),
+                },
+                {
+                    flutter::EncodableValue("width"),
+                    flutter::EncodableValue(video_output->width()),
+                },
+                {
+                    flutter::EncodableValue("height"),
+                    flutter::EncodableValue(video_output->height()),
+                },
+            }),
+        },
+    }));
+  } else if (method_call.method_name().compare("VideoOutputManager.Dispose") ==
+             0) {
     auto arguments = std::get<flutter::EncodableMap>(*method_call.arguments());
-    auto handle = std::get<std::string>(arguments[VALUE("handle")]);
+    auto handle =
+        std::get<std::string>(arguments[flutter::EncodableValue("handle")]);
     auto handle_value =
         static_cast<int64_t>(strtoll(handle.c_str(), nullptr, 10));
     video_output_manager_->Dispose(handle_value);
-    result->Success(VALUE(std::monostate{}));
+    result->Success(flutter::EncodableValue(std::monostate{}));
   } else {
     result->NotImplemented();
   }

--- a/media_kit_video/windows/thread_pool.h
+++ b/media_kit_video/windows/thread_pool.h
@@ -1,0 +1,82 @@
+// This file is a part of media_kit
+// (https://github.com/alexmercerind/media_kit).
+//
+// Copyright © 2021 & onwards, Hitesh Kumar Saini <saini123hitesh@gmail.com>.
+// All rights reserved.
+// Use of this source code is governed by MIT license that can be found in the
+// LICENSE file.
+#ifndef FLUTTER_PLUGIN_MEDIA_KIT_VIDEO_THREAD_POOL_H_
+#define FLUTTER_PLUGIN_MEDIA_KIT_VIDEO_THREAD_POOL_H_
+
+#include <functional>
+#include <future>
+#include <queue>
+
+class ThreadPool {
+ public:
+  explicit ThreadPool(size_t);
+  template <class F, class... Args>
+  decltype(auto) Post(F&& f, Args&&... args);
+  ~ThreadPool();
+
+ private:
+  std::vector<std::thread> workers_;
+  std::queue<std::packaged_task<void()>> tasks_;
+
+  std::mutex queue_mutex_;
+  std::condition_variable condition_;
+  std::condition_variable condition_producers_;
+  bool stop_;
+};
+
+inline ThreadPool::ThreadPool(size_t threads) : stop_(false) {
+  for (size_t i = 0; i < threads; i++)
+    workers_.emplace_back([&] {
+      for (;;) {
+        std::packaged_task<void()> task;
+        {
+          std::unique_lock<std::mutex> lock(queue_mutex_);
+          condition_.wait(lock, [&] { return stop_ || !tasks_.empty(); });
+          if (stop_ && tasks_.empty())
+            return;
+          task = std::move(tasks_.front());
+          tasks_.pop();
+          if (tasks_.empty()) {
+            condition_producers_.notify_one();
+          }
+        }
+        task();
+      }
+    });
+}
+
+template <class F, class... Args>
+decltype(auto) ThreadPool::Post(F&& f, Args&&... args) {
+  using return_type = std::invoke_result_t<F, Args...>;
+  std::packaged_task<return_type()> task(
+      std::bind(std::forward<F>(f), std::forward<Args>(args)...));
+  std::future<return_type> res = task.get_future();
+  {
+    std::unique_lock<std::mutex> lock(queue_mutex_);
+    if (stop_) {
+      throw std::runtime_error("ThreadPool::Post");
+    }
+    tasks_.emplace(std::move(task));
+  }
+  condition_.notify_one();
+  return res;
+}
+
+inline ThreadPool::~ThreadPool() {
+  {
+    std::unique_lock<std::mutex> lock(queue_mutex_);
+    condition_producers_.wait(lock, [this] { return tasks_.empty(); });
+    stop_ = true;
+  }
+  condition_.notify_all();
+  for (std::thread& worker : workers_) {
+    worker.join();
+  }
+}
+
+#endif

--- a/media_kit_video/windows/video_output.cc
+++ b/media_kit_video/windows/video_output.cc
@@ -29,122 +29,134 @@ VideoOutput::VideoOutput(int64_t handle,
                          std::optional<int64_t> width,
                          std::optional<int64_t> height,
                          flutter::PluginRegistrarWindows* registrar,
-                         std::mutex* render_mutex_ref)
+                         ThreadPool* thread_pool_ref)
     : handle_(reinterpret_cast<mpv_handle*>(handle)),
       width_(width),
       height_(height),
       registrar_(registrar),
-      render_mutex_ref_(render_mutex_ref) {
-  std::lock_guard<std::mutex> lock(*render_mutex_ref_);
-  // First try to initialize video playback with hardware acceleration &
-  // |ANGLESurfaceManager|, use S/W API as fallback.
-  auto is_hardware_acceleration_enabled = false;
-  // Attempt to use H/W rendering.
-  try {
-    // OpenGL context needs to be set before |mpv_render_context_create|.
-    surface_manager_ = std::make_unique<ANGLESurfaceManager>(
-        static_cast<int32_t>(width_.value_or(1)),
-        static_cast<int32_t>(height_.value_or(1)));
-    Resize(width_.value_or(1), height_.value_or(1));
-    mpv_opengl_init_params gl_init_params{
-        [](auto, auto name) {
-          return reinterpret_cast<void*>(eglGetProcAddress(name));
-        },
-        nullptr,
-    };
-    mpv_render_param params[] = {
-        {MPV_RENDER_PARAM_API_TYPE, MPV_RENDER_API_TYPE_OPENGL},
-        {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &gl_init_params},
-        {MPV_RENDER_PARAM_INVALID, nullptr},
-    };
-    // Request H/W decoding.
-    mpv_set_option_string(handle_, "hwdec", "auto");
-    // Create render context.
-    if (mpv_render_context_create(&render_context_, handle_, params) == 0) {
-      mpv_render_context_set_update_callback(
-          render_context_,
-          [](void* context) {
-            // Notify Flutter that a new frame is available. The actual
-            // rendering will take place in the |Render| method, which will be
-            // called by Flutter on the render thread.
-            auto that = reinterpret_cast<VideoOutput*>(context);
-            that->NotifyRender();
+      thread_pool_ref_(thread_pool_ref) {
+  // The constructor must be invoked through the thread pool, because
+  // |ANGLESurfaceManager| & libmpv render context creation can conflict with
+  // the existing |Render| or |Resize| calls from another |VideoOutput|
+  // instances (which will result in access violation).
+  auto future = thread_pool_ref_->Post([&]() {
+    // First try to initialize video playback with hardware acceleration &
+    // |ANGLESurfaceManager|, use S/W API as fallback.
+    auto is_hardware_acceleration_enabled = false;
+    // Attempt to use H/W rendering.
+    try {
+      // OpenGL context needs to be set before |mpv_render_context_create|.
+      surface_manager_ = std::make_unique<ANGLESurfaceManager>(
+          static_cast<int32_t>(width_.value_or(1)),
+          static_cast<int32_t>(height_.value_or(1)));
+      Resize(width_.value_or(1), height_.value_or(1));
+      mpv_opengl_init_params gl_init_params{
+          [](auto, auto name) {
+            return reinterpret_cast<void*>(eglGetProcAddress(name));
           },
-          reinterpret_cast<void*>(this));
-      // Set flag to true, indicating that H/W rendering is supported.
-      is_hardware_acceleration_enabled = true;
-      std::cout << "media_kit: VideoOutput: Using H/W rendering." << std::endl;
+          nullptr,
+      };
+      mpv_render_param params[] = {
+          {MPV_RENDER_PARAM_API_TYPE, MPV_RENDER_API_TYPE_OPENGL},
+          {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &gl_init_params},
+          {MPV_RENDER_PARAM_INVALID, nullptr},
+      };
+      // Request H/W decoding.
+      mpv_set_option_string(handle_, "hwdec", "auto");
+      // Create render context.
+      if (mpv_render_context_create(&render_context_, handle_, params) == 0) {
+        mpv_render_context_set_update_callback(
+            render_context_,
+            [](void* context) {
+              // Notify Flutter that a new frame is available. The actual
+              // rendering will take place in the |Render| method, which will be
+              // called by Flutter on the render thread.
+              auto that = reinterpret_cast<VideoOutput*>(context);
+              that->NotifyRender();
+            },
+            reinterpret_cast<void*>(this));
+        // Set flag to true, indicating that H/W rendering is supported.
+        is_hardware_acceleration_enabled = true;
+        std::cout << "media_kit: VideoOutput: Using H/W rendering."
+                  << std::endl;
+      }
+    } catch (...) {
+      // Do nothing.
+      // Likely received an |std::runtime_error| from |ANGLESurfaceManager|,
+      // which indicates that H/W rendering is not supported.
     }
-  } catch (...) {
-    // Do nothing.
-    // Likely received an |std::runtime_error| from |ANGLESurfaceManager|,
-    // which indicates that H/W rendering is not supported.
-  }
-  if (!is_hardware_acceleration_enabled) {
-    std::cout << "media_kit: VideoOutput: Using S/W rendering." << std::endl;
-    // Allocate a "large enough" buffer ahead of time.
-    pixel_buffer_ = std::make_unique<uint8_t[]>(SW_RENDERING_PIXEL_BUFFER_SIZE);
-    Resize(width_.value_or(1), height_.value_or(1));
-    mpv_render_param params[] = {
-        {MPV_RENDER_PARAM_API_TYPE, MPV_RENDER_API_TYPE_SW},
-        {MPV_RENDER_PARAM_INVALID, nullptr},
-    };
-    if (mpv_render_context_create(&render_context_, handle_, params) == 0) {
-      mpv_render_context_set_update_callback(
-          render_context_,
-          [](void* context) {
-            // Notify Flutter that a new frame is available. The actual
-            // rendering will take place in the |Render| method, which will be
-            // called by Flutter on the render thread.
-            auto that = reinterpret_cast<VideoOutput*>(context);
-            that->NotifyRender();
-          },
-          reinterpret_cast<void*>(this));
+    if (!is_hardware_acceleration_enabled) {
+      std::cout << "media_kit: VideoOutput: Using S/W rendering." << std::endl;
+      // Allocate a "large enough" buffer ahead of time.
+      pixel_buffer_ =
+          std::make_unique<uint8_t[]>(SW_RENDERING_PIXEL_BUFFER_SIZE);
+      Resize(width_.value_or(1), height_.value_or(1));
+      mpv_render_param params[] = {
+          {MPV_RENDER_PARAM_API_TYPE, MPV_RENDER_API_TYPE_SW},
+          {MPV_RENDER_PARAM_INVALID, nullptr},
+      };
+      if (mpv_render_context_create(&render_context_, handle_, params) == 0) {
+        mpv_render_context_set_update_callback(
+            render_context_,
+            [](void* context) {
+              // Notify Flutter that a new frame is available. The actual
+              // rendering will take place in the |Render| method, which will be
+              // called by Flutter on the render thread.
+              auto that = reinterpret_cast<VideoOutput*>(context);
+              that->NotifyRender();
+            },
+            reinterpret_cast<void*>(this));
+      }
     }
-  };
+  });
+  future.wait();
 }
 
 VideoOutput::~VideoOutput() {
-  std::promise<void> alive;
   if (texture_id_) {
-    registrar_->texture_registrar()->UnregisterTexture(
-        texture_id_, [alive_ptr = &alive, id = texture_id_, that = this]() {
-          std::cout << "media_kit: VideoOutput: Free Texture: " << id
-                    << std::endl;
-          if (that->texture_variants_.find(id) !=
-              that->texture_variants_.end()) {
-            that->texture_variants_.erase(id);
-          }
-          // H/W
-          if (that->textures_.find(id) != that->textures_.end()) {
-            that->textures_.erase(id);
-          }
-          // S/W
-          if (that->pixel_buffer_textures_.find(id) !=
-              that->pixel_buffer_textures_.end()) {
-            that->pixel_buffer_textures_.erase(id);
-          }
-          alive_ptr->set_value();
-        });
+    auto promise = std::make_unique<std::promise<void>>();
+    registrar_->texture_registrar()->UnregisterTexture(texture_id_, [&]() {
+      auto id = texture_id_;
+      std::cout << "media_kit: VideoOutput: Free Texture: " << id << std::endl;
+      if (texture_variants_.find(id) != texture_variants_.end()) {
+        texture_variants_.erase(id);
+      }
+      // H/W
+      if (textures_.find(id) != textures_.end()) {
+        textures_.erase(id);
+      }
+      // S/W
+      if (pixel_buffer_textures_.find(id) != pixel_buffer_textures_.end()) {
+        pixel_buffer_textures_.erase(id);
+      }
+      promise->set_value();
+    });
+    promise->get_future().wait();
     texture_id_ = 0;
   }
   if (render_context_) {
     mpv_render_context_free(render_context_);
   }
-  alive.get_future().wait();
+  // Add one more lambda into the thread pool queue & exit the destructor only
+  // when it gets executed. This will ensure that all the tasks posted to the
+  // thread pool are executed (and won't reference the dead object anymore),
+  // most notably |CheckAndResize| & |Render|.
+  auto promise = std::make_unique<std::promise<void>>();
+  thread_pool_ref_->Post([&]() {
+    std::cout << "VideoOutput::~VideoOutput: "
+              << reinterpret_cast<int64_t>(handle_) << std::endl;
+    promise->set_value();
+  });
+  promise->get_future().wait();
 }
 
 void VideoOutput::NotifyRender() {
-  // Ask Flutter to invoke the |Render|.
-  if (texture_id_) {
-    registrar_->texture_registrar()->MarkTextureFrameAvailable(texture_id_);
-  }
+  thread_pool_ref_->Post(std::bind(&VideoOutput::CheckAndResize, this));
+  thread_pool_ref_->Post(std::bind(&VideoOutput::Render, this));
 }
 
 void VideoOutput::Render() {
-  std::lock_guard<std::mutex> lock(*render_mutex_ref_);
   if (texture_id_) {
-    CheckAndResize();
     // H/W
     if (surface_manager_ != nullptr) {
       surface_manager_->MakeCurrent(true);
@@ -181,12 +193,19 @@ void VideoOutput::Render() {
       };
       mpv_render_context_render(render_context_, params);
     }
+    // Notify Flutter that a new frame is available.
+    try {
+      registrar_->texture_registrar()->MarkTextureFrameAvailable(texture_id_);
+    } catch (...) {
+      // Do not crash if the texture is already unregistered.
+    }
   }
 }
 
 void VideoOutput::SetTextureUpdateCallback(
     std::function<void(int64_t, int64_t, int64_t)> callback) {
   texture_update_callback_ = callback;
+  texture_update_callback_(texture_id_, GetVideoWidth(), GetVideoHeight());
 }
 
 void VideoOutput::CheckAndResize() {
@@ -221,21 +240,19 @@ void VideoOutput::Resize(int64_t required_width, int64_t required_height) {
   // Unregister previously registered texture.
   if (texture_id_) {
     registrar_->texture_registrar()->UnregisterTexture(
-        texture_id_, [id = texture_id_, that = this]() {
+        texture_id_, [id = texture_id_, this]() {
           std::cout << "media_kit: VideoOutput: Free Texture: " << id
                     << std::endl;
-          if (that->texture_variants_.find(id) !=
-              that->texture_variants_.end()) {
-            that->texture_variants_.erase(id);
+          if (texture_variants_.find(id) != texture_variants_.end()) {
+            texture_variants_.erase(id);
           }
           // H/W
-          if (that->textures_.find(id) != that->textures_.end()) {
-            that->textures_.erase(id);
+          if (textures_.find(id) != textures_.end()) {
+            textures_.erase(id);
           }
           // S/W
-          if (that->pixel_buffer_textures_.find(id) !=
-              that->pixel_buffer_textures_.end()) {
-            that->pixel_buffer_textures_.erase(id);
+          if (pixel_buffer_textures_.find(id) != pixel_buffer_textures_.end()) {
+            pixel_buffer_textures_.erase(id);
           }
         });
     texture_id_ = 0;
@@ -259,7 +276,6 @@ void VideoOutput::Resize(int64_t required_width, int64_t required_height) {
             kFlutterDesktopGpuSurfaceTypeDxgiSharedHandle,
             [&](auto, auto) -> FlutterDesktopGpuSurfaceDescriptor* {
               if (texture_id_) {
-                Render();
                 return textures_.at(texture_id_).get();
               }
               return nullptr;
@@ -287,7 +303,6 @@ void VideoOutput::Resize(int64_t required_width, int64_t required_height) {
         std::make_unique<flutter::TextureVariant>(flutter::PixelBufferTexture(
             [&](auto, auto) -> FlutterDesktopPixelBuffer* {
               if (texture_id_) {
-                Render();
                 return pixel_buffer_textures_.at(texture_id_).get();
               }
               return nullptr;

--- a/media_kit_video/windows/video_output.h
+++ b/media_kit_video/windows/video_output.h
@@ -17,13 +17,13 @@
 
 #include <future>
 #include <memory>
-#include <mutex>
 
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>
 #include <flutter/standard_method_codec.h>
 
 #include "angle_surface_manager.h"
+#include "thread_pool.h"
 
 class VideoOutput {
  public:
@@ -55,7 +55,7 @@ class VideoOutput {
               std::optional<int64_t> width,
               std::optional<int64_t> height,
               flutter::PluginRegistrarWindows* registrar,
-              std::mutex* render_mutex_ref);
+              ThreadPool* thread_pool_ref);
 
   ~VideoOutput();
 
@@ -81,12 +81,10 @@ class VideoOutput {
   std::optional<int64_t> width_ = std::nullopt;
   int64_t texture_id_ = 0;
   flutter::PluginRegistrarWindows* registrar_ = nullptr;
+  ThreadPool* thread_pool_ref_ = nullptr;
 
   std::unordered_map<int64_t, std::unique_ptr<flutter::TextureVariant>>
       texture_variants_ = {};
-
-  // For syncing |Render| across multiple instances of |VideoOutput|.
-  std::mutex* render_mutex_ref_ = nullptr;
 
   // H/W rendering.
 

--- a/media_kit_video/windows/video_output_manager.h
+++ b/media_kit_video/windows/video_output_manager.h
@@ -13,29 +13,68 @@
 
 #include <unordered_map>
 
+#include "thread_pool.h"
 #include "video_output.h"
 
-// Creates & disposes |VideoOutput| instances for video embedding inside Flutter
-// Windows. |Create| & |Dispose| methods are thread-safe.
+// Creates & disposes |VideoOutput| instances for video embedding.
+//
+// The methods in this class are thread-safe & run on separate worker thread so
+// that they don't block Flutter's UI thread while platform channels are being
+// invoked.
 class VideoOutputManager {
  public:
   VideoOutputManager(flutter::PluginRegistrarWindows* registrar);
 
-  // Creates a new |VideoOutput| and returns reference to it.
-  // It's texture ID may be used to render the video.
-  VideoOutput* Create(
+  // Creates a new |VideoOutput| instance. It's texture ID may be used to render
+  // the video. The changes in it's texture ID & video dimensions will be
+  // notified via the |texture_update_callback|.
+  void Create(
       int64_t handle,
       std::optional<int64_t> width,
       std::optional<int64_t> height,
       std::function<void(int64_t, int64_t, int64_t)> texture_update_callback);
 
   // Destroys the |VideoOutput| with given handle.
-  bool Dispose(int64_t handle);
+  void Dispose(int64_t handle);
 
   ~VideoOutputManager();
 
  private:
-  std::mutex render_mutex_ = std::mutex();
+  // All the operations involving ANGLE or EGL or libmpv must be performed on
+  // same single thread to prevent any race conditions or invalid ANGLE usage.
+  // Not doing so results in access violations & crashes.
+  //
+  // Technically, the correct place to do all the video rendering (& thus
+  // resize) etc. is on Flutter's render thread itself (exposed as callback in
+  // |flutter::GpuSurfaceTexture| & |flutter::PixelBufferTexture|). However,
+  // this slows down the UI too much. So, I decided to create our own
+  // |ThreadPool| & use it for all the video rendering purposes through one
+  // single thread.
+  //
+  // Secondly, setting a |std::mutex| was not enough. It still resulted in
+  // access violations. Maybe it does not provide a fair mutex, which caused
+  // race between resize & render.
+  //
+  // The following operations are performed through the |ThreadPool|:
+  // All of these involve ANGLE or OpenGL context etc. etc.
+  //
+  // * Rendering of video frame i.e. |mpv_render_context_render| is called
+  //   through the |ThreadPool| after being notified by
+  //   |mpv_render_context_set_update_callback|.
+  // * Creation / Disposal of new |VideoOutput| i.e.
+  //   |VideoOutputManager::Create| & |VideoOutputManager::Dispose| are called
+  //   through the |ThreadPool|. Thus, |mpv_render_context_create| is called &
+  //   instantiation of a new |ANGLESurfaceManager| is done through |ThreadPool|
+  //   (in |VideoOutput| constructor).
+  // * Resizing of |ANGLESurfaceManager| & creation of newly sized Flutter
+  //   textures (|flutter::GpuSurfaceTexture| & |flutter::PixelBufferTexture|)
+  //   is also done through |ThreadPool|. See |VideoOutput::CheckAndResize|.
+  //
+  // Thus, creating a new |ThreadPool| with maximum number of worker threads as
+  // 1, ensures that all the ANGLE, EGL & libmpv operations are performed on a
+  // single thread orderly. This also makes usage of any |std::mutex|
+  // unnecessary.
+  std::unique_ptr<ThreadPool> thread_pool_ = std::make_unique<ThreadPool>(1);
   flutter::PluginRegistrarWindows* registrar_ = nullptr;
   std::unordered_map<int64_t, std::unique_ptr<VideoOutput>> video_outputs_ = {};
 };

--- a/media_kit_video/windows/video_output_manager.h
+++ b/media_kit_video/windows/video_output_manager.h
@@ -9,30 +9,25 @@
 #ifndef FLUTTER_PLUGIN_MEDIA_KIT_VIDEO_VIDEO_OUTPUT_MANAGER_H_
 #define FLUTTER_PLUGIN_MEDIA_KIT_VIDEO_VIDEO_OUTPUT_MANAGER_H_
 
-#include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>
-#include <flutter/standard_method_codec.h>
 
 #include <unordered_map>
 
 #include "video_output.h"
 
-// Fuck that syntax.
-#define VALUE(x) flutter::EncodableValue(x)
-#define IS_METHOD(x) method_call.method_name().compare(x) == 0
-
 // Creates & disposes |VideoOutput| instances for video embedding inside Flutter
 // Windows. |Create| & |Dispose| methods are thread-safe.
 class VideoOutputManager {
  public:
-  VideoOutputManager(flutter::PluginRegistrarWindows* registrar,
-                     flutter::MethodChannel<flutter::EncodableValue>* channel);
+  VideoOutputManager(flutter::PluginRegistrarWindows* registrar);
 
   // Creates a new |VideoOutput| and returns reference to it.
   // It's texture ID may be used to render the video.
-  VideoOutput* Create(int64_t handle,
-                      std::optional<int64_t> width,
-                      std::optional<int64_t> height);
+  VideoOutput* Create(
+      int64_t handle,
+      std::optional<int64_t> width,
+      std::optional<int64_t> height,
+      std::function<void(int64_t, int64_t, int64_t)> texture_update_callback);
 
   // Destroys the |VideoOutput| with given handle.
   bool Dispose(int64_t handle);
@@ -40,10 +35,8 @@ class VideoOutputManager {
   ~VideoOutputManager();
 
  private:
-  std::mutex mutex_ = std::mutex();
   std::mutex render_mutex_ = std::mutex();
   flutter::PluginRegistrarWindows* registrar_ = nullptr;
-  flutter::MethodChannel<flutter::EncodableValue>* channel_ = nullptr;
   std::unordered_map<int64_t, std::unique_ptr<VideoOutput>> video_outputs_ = {};
 };
 


### PR DESCRIPTION
~~Now Flutter UI feels much snappier than before & no longer feels "slowed down" when one or more videos are visible.~~

~~Technically, the correct place to do all the video rendering (& thus resize) etc. is on Flutter's render thread itself (exposed as callback in flutter::GpuSurfaceTexture & flutter::PixelBufferTexture). However, this slows down the UI too much. So, I decided to create our own ThreadPool & use it for all the video rendering purposes through one single thread.~~

All the operations involving ANGLE or EGL or libmpv must be performed on same single thread to prevent any race conditions or invalid ANGLE usage. Not doing so results in access violations & crashes (#17).

The following operations are performed through the ThreadPool:
* Rendering of video frame i.e. mpv_render_context_render is called through the ThreadPool after being notified by mpv_render_context_set_update_callback.
* Creation / Disposal of new VideoOutput i.e. VideoOutputManager::Create & VideoOutputManager::Dispose are called through the ThreadPool. Thus, mpv_render_context_create is called & instantiation of a new ANGLESurfaceManager is done through ThreadPool (in VideoOutput constructor).
* Resizing of ANGLESurfaceManager & creation of newly sized Flutter textures (flutter::GpuSurfaceTexture & flutter::PixelBufferTexture).

All of these involve ANGLE or OpenGL context etc. etc.

Creating a ThreadPool with maximum number of worker threads as 1, ensures that all the ANGLE, EGL & libmpv operations are performed on a single thread **orderly**. This also makes usage of any std::mutex unnecessary (for the good).