### PR TITLE
perf(win): improve rendering synchronization & support stable channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           submodules: "true"
       - uses: subosito/flutter-action@v1
         with:
-          channel: "master"
+          channel: "stable"
       - run: flutter pub get
       - run: flutter build windows --verbose
       - uses: actions/upload-artifact@v1

--- a/README.md
+++ b/README.md
@@ -412,8 +412,8 @@ classDiagram
 
   MediaKitVideoPlugin "1" *-- "1" VideoOutputManager: Create VideoOutput(s) with VideoOutputManager for handle passed through platform channel
   VideoOutputManager "1" *-- "*" VideoOutput
-  VideoOutputManager "1" *-- "1" ThreadPool:
-  VideoOutput "1" o-- "1" ThreadPool: Post creation, resize & render etc. tasks involving EGL to ensure synchronous EGL/ANGLE usage across multiple VideoOutput(s)
+  VideoOutputManager "1" *-- "1" ThreadPool
+  VideoOutput "*" o-- "1" ThreadPool: Post creation, resize & render etc. tasks involving EGL to ensure synchronous EGL/ANGLE usage across multiple VideoOutput(s)
   VideoOutput "1" *-- "1" ANGLESurfaceManager: Only for H/W accelerated rendering
 
   class MediaKitVideoPlugin {
@@ -467,13 +467,16 @@ classDiagram
     +«get» handle: HANDLE
 
     +HandleResize(width: int32_t, height: int32_t)
+    +Draw(draw_callback: std::function<void()>)
+    +RequestFrame()
     +SwapBuffers()
     +MakeCurrent(value: bool)
+    -CreateEGLDisplay()
     -Initialize()
     -InitializeD3D11()
     -InitializeD3D9()
     -CleanUp(release_context: bool)
-    -CreateAndBindEGLSurface()
+    -CreateEGLDisplay()
     -ShowFailureMessage(message: wchar_t[])
 
     -IDXGIAdapter* adapter_

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ classDiagram
 
     +HandleResize(width: int32_t, height: int32_t)
     +Draw(draw_callback: std::function<void()>)
-    +RequestFrame()
+    +Read()
     +SwapBuffers()
     +MakeCurrent(value: bool)
     -CreateEGLDisplay()

--- a/media_kit_video/windows/CMakeLists.txt
+++ b/media_kit_video/windows/CMakeLists.txt
@@ -17,26 +17,6 @@ set(PLUGIN_NAME "media_kit_video_plugin")
 set(LIBMPV_SRC "${CMAKE_BINARY_DIR}/libmpv")
 set(ANGLE_SRC "${CMAKE_BINARY_DIR}/ANGLE")
 
-add_definitions(
-
-  # Some GPUs/Hardware seem to experience black flickering when rendering with hardware acceleration.
-  # Calling |glFinish| eliminates this. This seems to be some sort of synchronization problem between Flutter / Monitor / mpv etc.
-  # Now there are bunch of |glFinish| calls inside |ANGLESurfaceManager| & |VideoOutput| classes which fix any flickering issues.
-  # There doesn't seem to be any better alternative for OpenGL ES 2.0. See:
-  #
-  # * https://github.com/alexmercerind/media_kit/issues/10
-  # * https://github.com/alexmercerind/media_kit/pull/11
-  # * https://stackoverflow.com/a/12157120/12825435
-  #
-  # Though |glFinish| is not optimal, it is still way-way better in terms of performance as compared to software rendering.
-  # Personally, my budget machine with AMD Ryzen 3 2200U with integrated Radeon Vega 3 Mobile Graphics never experienced this issue.
-  # At most, 4K 30FPS or 1080p 60FPS videos play flawlessly without any major load on the hardware. 4K 60FPS videos certainly experience some frame drops. But nothing that can be referred as flicker.
-  -DENABLE_GL_FINISH_SAFEGUARD
-
-  # Query ID3D11Device from ANGLE itself instead of enumerating / creating a new one.
-  -DENABLE_ID3D11DEVICE_FROM_ANGLE
-)
-
 # Add libmpv & ANGLE headers to the include path.
 include_directories(
   "${LIBMPV_SRC}/include"

--- a/media_kit_video/windows/angle_surface_manager.cc
+++ b/media_kit_video/windows/angle_surface_manager.cc
@@ -45,16 +45,16 @@ void ANGLESurfaceManager::HandleResize(int32_t width, int32_t height) {
   Initialize();
 }
 
-void ANGLESurfaceManager::Draw(std::function<void()> draw_callback) {
-  std::lock_guard<std::mutex> lock(draw_mutex_);
+void ANGLESurfaceManager::Draw(std::function<void()> callback) {
+  std::lock_guard<std::mutex> lock(mutex_);
   MakeCurrent(true);
-  draw_callback();
+  callback();
   SwapBuffers();
   MakeCurrent(false);
 }
 
-void ANGLESurfaceManager::RequestFrame() {
-  std::lock_guard<std::mutex> lock(draw_mutex_);
+void ANGLESurfaceManager::Read() {
+  std::lock_guard<std::mutex> lock(mutex_);
   // Only supported on D3D 11 code path.
   if (d3d_11_device_context_ != nullptr) {
     d3d_11_device_context_->CopyResource(d3d_11_texture_2D_.Get(),

--- a/media_kit_video/windows/angle_surface_manager.h
+++ b/media_kit_video/windows/angle_surface_manager.h
@@ -27,7 +27,6 @@
 
 #include <cstdint>
 #include <functional>
-#include <mutex>
 
 class ANGLESurfaceManager {
  public:
@@ -91,7 +90,7 @@ class ANGLESurfaceManager {
   HANDLE handle_ = nullptr;
 
   // Sync |Draw| & |Read| calls.
-  std::mutex mutex_ = std::mutex();
+  HANDLE mutex_ = nullptr;
   // D3D 11 specific references.
   ID3D11Device* d3d_11_device_ = nullptr;
   ID3D11DeviceContext* d3d_11_device_context_ = nullptr;

--- a/media_kit_video/windows/angle_surface_manager.h
+++ b/media_kit_video/windows/angle_surface_manager.h
@@ -49,11 +49,11 @@ class ANGLESurfaceManager {
   //
   // Automatically acquires & releases |context_| before & after |draw_callback|
   // is completed. Ensures synchronization with |RequestFrame| aswell.
-  void Draw(std::function<void()> draw_callback);
+  void Draw(std::function<void()> callback);
 
   // Copies the rendered content from internal |ID3D11Texture2D| to public
   // |ID3D11Texture2D|. The |handle| may be used to access the rendered content.
-  void RequestFrame();
+  void Read();
 
   void SwapBuffers();
 
@@ -90,8 +90,8 @@ class ANGLESurfaceManager {
   HANDLE internal_handle_ = nullptr;
   HANDLE handle_ = nullptr;
 
-  // Sync |Draw| & |RequestFrame| calls.
-  std::mutex draw_mutex_ = std::mutex();
+  // Sync |Draw| & |Read| calls.
+  std::mutex mutex_ = std::mutex();
   // D3D 11 specific references.
   ID3D11Device* d3d_11_device_ = nullptr;
   ID3D11DeviceContext* d3d_11_device_context_ = nullptr;

--- a/media_kit_video/windows/angle_surface_manager.h
+++ b/media_kit_video/windows/angle_surface_manager.h
@@ -26,6 +26,8 @@
 #include <wrl.h>
 
 #include <cstdint>
+#include <functional>
+#include <mutex>
 
 class ANGLESurfaceManager {
  public:
@@ -39,10 +41,19 @@ class ANGLESurfaceManager {
 
   ~ANGLESurfaceManager();
 
-  // Resizes the internal |ID3D11Texture2D| & |EGLSurface| and returns updated
-  // |handle_|. This preserves the |context_| & |display_| associated
-  // with this |ANGLESurfaceManager| instance.
-  HANDLE HandleResize(int32_t width, int32_t height);
+  // Resizes the internal |ID3D11Texture2D| & |EGLSurface|. This preserves the
+  // |context_| & |display_| associated with this instance.
+  void HandleResize(int32_t width, int32_t height);
+
+  // May be used to draw content on the |EGLSurface| using ANGLE.
+  //
+  // Automatically acquires & releases |context_| before & after |draw_callback|
+  // is completed. Ensures synchronization with |RequestFrame| aswell.
+  void Draw(std::function<void()> draw_callback);
+
+  // Copies the rendered content from internal |ID3D11Texture2D| to public
+  // |ID3D11Texture2D|. The |handle| may be used to access the rendered content.
+  void RequestFrame();
 
   void SwapBuffers();
 
@@ -76,17 +87,21 @@ class ANGLESurfaceManager {
   IDXGIAdapter* adapter_ = nullptr;
   int32_t width_ = 1;
   int32_t height_ = 1;
+  HANDLE internal_handle_ = nullptr;
+  HANDLE handle_ = nullptr;
+
+  // Sync |Draw| & |RequestFrame| calls.
+  std::mutex draw_mutex_ = std::mutex();
   // D3D 11 specific references.
   ID3D11Device* d3d_11_device_ = nullptr;
   ID3D11DeviceContext* d3d_11_device_context_ = nullptr;
-  Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d11_texture_2D_;
-  Microsoft::WRL::ComPtr<IDXGISwapChain> d3d11_swap_chain_;
+  Microsoft::WRL::ComPtr<ID3D11Texture2D> internal_d3d_11_texture_2D_;
+  Microsoft::WRL::ComPtr<ID3D11Texture2D> d3d_11_texture_2D_;
   // D3D 9 specific references.
   IDirect3D9Ex* d3d_9_ex_ = nullptr;
   IDirect3DDevice9Ex* d3d_9_device_ex_ = nullptr;
   IDirect3DTexture9* d3d_9_texture_ = nullptr;
   // ANGLE specific references.
-  HANDLE handle_ = nullptr;
   EGLSurface surface_ = EGL_NO_SURFACE;
   EGLDisplay display_ = EGL_NO_DISPLAY;
   EGLContext context_ = nullptr;

--- a/media_kit_video/windows/video_output.cc
+++ b/media_kit_video/windows/video_output.cc
@@ -151,28 +151,27 @@ VideoOutput::~VideoOutput() {
 }
 
 void VideoOutput::NotifyRender() {
-  thread_pool_ref_->Post([&]() { CheckAndResize(); });
-  registrar_->texture_registrar()->MarkTextureFrameAvailable(texture_id_);
+  thread_pool_ref_->Post(std::bind(&VideoOutput::CheckAndResize, this));
+  thread_pool_ref_->Post(std::bind(&VideoOutput::Render, this));
 }
 
 void VideoOutput::Render() {
   if (texture_id_) {
     // H/W
     if (surface_manager_ != nullptr) {
-      surface_manager_->MakeCurrent(true);
-      mpv_opengl_fbo fbo{
-          0,
-          surface_manager_->width(),
-          surface_manager_->height(),
-          0,
-      };
-      mpv_render_param params[]{
-          {MPV_RENDER_PARAM_OPENGL_FBO, &fbo},
-          {MPV_RENDER_PARAM_INVALID, nullptr},
-      };
-      mpv_render_context_render(render_context_, params);
-      surface_manager_->SwapBuffers();
-      surface_manager_->MakeCurrent(false);
+      surface_manager_->Draw([&]() {
+        mpv_opengl_fbo fbo{
+            0,
+            surface_manager_->width(),
+            surface_manager_->height(),
+            0,
+        };
+        mpv_render_param params[]{
+            {MPV_RENDER_PARAM_OPENGL_FBO, &fbo},
+            {MPV_RENDER_PARAM_INVALID, nullptr},
+        };
+        mpv_render_context_render(render_context_, params);
+      });
     }
     // S/W
     if (pixel_buffer_ != nullptr) {
@@ -189,6 +188,12 @@ void VideoOutput::Render() {
           {MPV_RENDER_PARAM_INVALID, nullptr},
       };
       mpv_render_context_render(render_context_, params);
+    }
+    try {
+      // Notify Flutter that a new frame is available.
+      registrar_->texture_registrar()->MarkTextureFrameAvailable(texture_id_);
+    } catch (...) {
+      // Prevent any redundant exceptions if the texture is unregistered etc.
     }
   }
 }
@@ -267,8 +272,7 @@ void VideoOutput::Resize(int64_t required_width, int64_t required_height) {
             kFlutterDesktopGpuSurfaceTypeDxgiSharedHandle,
             [&](auto, auto) -> FlutterDesktopGpuSurfaceDescriptor* {
               if (texture_id_) {
-                auto future = thread_pool_ref_->Post([&]() { Render(); });
-                future.wait();
+                surface_manager_->RequestFrame();
                 return textures_.at(texture_id_).get();
               }
               return nullptr;
@@ -296,8 +300,6 @@ void VideoOutput::Resize(int64_t required_width, int64_t required_height) {
         std::make_unique<flutter::TextureVariant>(flutter::PixelBufferTexture(
             [&](auto, auto) -> FlutterDesktopPixelBuffer* {
               if (texture_id_) {
-                auto future = thread_pool_ref_->Post([&]() { Render(); });
-                future.wait();
                 return pixel_buffer_textures_.at(texture_id_).get();
               }
               return nullptr;

--- a/media_kit_video/windows/video_output.cc
+++ b/media_kit_video/windows/video_output.cc
@@ -113,10 +113,16 @@ VideoOutput::VideoOutput(int64_t handle,
 }
 
 VideoOutput::~VideoOutput() {
+  destroyed_ = true;
   if (texture_id_) {
-    auto promise = std::make_unique<std::promise<void>>();
-    registrar_->texture_registrar()->UnregisterTexture(texture_id_, [&]() {
-      auto id = texture_id_;
+    registrar_->texture_registrar()->UnregisterTexture(texture_id_);
+  }
+  // Add one more task into the thread pool queue & exit the destructor only
+  // when it gets executed. This will ensure that all the tasks posted to the
+  // thread pool before this are executed (and won't reference the dead object
+  // anymore), most notably |CheckAndResize| & |Render|.
+  auto future = thread_pool_ref_->Post([&, id = texture_id_]() {
+    if (id) {
       std::cout << "media_kit: VideoOutput: Free Texture: " << id << std::endl;
       if (texture_variants_.find(id) != texture_variants_.end()) {
         texture_variants_.erase(id);
@@ -129,28 +135,20 @@ VideoOutput::~VideoOutput() {
       if (pixel_buffer_textures_.find(id) != pixel_buffer_textures_.end()) {
         pixel_buffer_textures_.erase(id);
       }
-      promise->set_value();
-    });
-    promise->get_future().wait();
-    texture_id_ = 0;
-  }
+    }
+    std::cout << "VideoOutput::~VideoOutput: "
+              << reinterpret_cast<int64_t>(handle_) << std::endl;
+  });
+  future.wait();
   if (render_context_) {
     mpv_render_context_free(render_context_);
   }
-  // Add one more lambda into the thread pool queue & exit the destructor only
-  // when it gets executed. This will ensure that all the tasks posted to the
-  // thread pool are executed (and won't reference the dead object anymore),
-  // most notably |CheckAndResize| & |Render|.
-  auto promise = std::make_unique<std::promise<void>>();
-  thread_pool_ref_->Post([&]() {
-    std::cout << "VideoOutput::~VideoOutput: "
-              << reinterpret_cast<int64_t>(handle_) << std::endl;
-    promise->set_value();
-  });
-  promise->get_future().wait();
 }
 
 void VideoOutput::NotifyRender() {
+  if (destroyed_) {
+    return;
+  }
   thread_pool_ref_->Post(std::bind(&VideoOutput::CheckAndResize, this));
   thread_pool_ref_->Post(std::bind(&VideoOutput::Render, this));
 }
@@ -235,23 +233,29 @@ void VideoOutput::Resize(int64_t required_width, int64_t required_height) {
   std::cout << required_width << " " << required_height << std::endl;
   // Unregister previously registered texture.
   if (texture_id_) {
-    registrar_->texture_registrar()->UnregisterTexture(
-        texture_id_, [id = texture_id_, this]() {
-          std::cout << "media_kit: VideoOutput: Free Texture: " << id
-                    << std::endl;
-          if (texture_variants_.find(id) != texture_variants_.end()) {
-            texture_variants_.erase(id);
-          }
-          // H/W
-          if (textures_.find(id) != textures_.end()) {
-            textures_.erase(id);
-          }
-          // S/W
-          if (pixel_buffer_textures_.find(id) != pixel_buffer_textures_.end()) {
-            pixel_buffer_textures_.erase(id);
-          }
-        });
+    registrar_->texture_registrar()->UnregisterTexture(texture_id_);
     texture_id_ = 0;
+    // Add one more task into the thread pool queue for clearing the previous
+    // texture objects. This will ensure that all the tasks posted to the thread
+    // pool before this are executed (and won't reference the dead object
+    // anymore), most notably |CheckAndResize| & |Render|.
+    thread_pool_ref_->Post([&, id = texture_id_]() {
+      if (id) {
+        std::cout << "media_kit: VideoOutput: Free Texture: " << id
+                  << std::endl;
+        if (texture_variants_.find(id) != texture_variants_.end()) {
+          texture_variants_.erase(id);
+        }
+        // H/W
+        if (textures_.find(id) != textures_.end()) {
+          textures_.erase(id);
+        }
+        // S/W
+        if (pixel_buffer_textures_.find(id) != pixel_buffer_textures_.end()) {
+          pixel_buffer_textures_.erase(id);
+        }
+      }
+    });
   }
   // H/W
   if (surface_manager_ != nullptr) {

--- a/media_kit_video/windows/video_output.cc
+++ b/media_kit_video/windows/video_output.cc
@@ -272,7 +272,7 @@ void VideoOutput::Resize(int64_t required_width, int64_t required_height) {
             kFlutterDesktopGpuSurfaceTypeDxgiSharedHandle,
             [&](auto, auto) -> FlutterDesktopGpuSurfaceDescriptor* {
               if (texture_id_) {
-                surface_manager_->RequestFrame();
+                surface_manager_->Read();
                 return textures_.at(texture_id_).get();
               }
               return nullptr;

--- a/media_kit_video/windows/video_output.h
+++ b/media_kit_video/windows/video_output.h
@@ -82,6 +82,7 @@ class VideoOutput {
   int64_t texture_id_ = 0;
   flutter::PluginRegistrarWindows* registrar_ = nullptr;
   ThreadPool* thread_pool_ref_ = nullptr;
+  bool destroyed_ = false;
 
   std::unordered_map<int64_t, std::unique_ptr<flutter::TextureVariant>>
       texture_variants_ = {};


### PR DESCRIPTION
## Introduction

Now two instances of `ID3D11Texture2D` are created inside `ANGLESurfaceManager`. First one for drawing onto using ANGLE/EGL (libmpv) & second one which gets copied from the first one upon every request. The `ID3D11Texture2D` requested by the public API & gets copied to right before every render request (ANGLESurfaceManager::Read). It's shared HANDLE is exposed in the `ANGLESurfaceManager::handle` getter. 

`ANGLESurfaceManager::Draw` & `ANGLESurfaceManager::Read` abstract the process of EGL context acquiring & rendering. A single mutex is also involved.

This removes any possible races & synchronization issues between libmpv & Flutter _i.e._ flickers (#10) without needing any redundant `glFinish` calls (#11).

- `ANGLESurfaceManager::Draw`:
  - Call ANGLE/EGL/libmpv APIs in it's callback & perform rendering onto internal `ID3D11Texture2D`.
- `ANGLESurfaceManager::Read`:
  - Access the rendered content [after copying the internal texture to a separate public texture](https://learn.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11devicecontext-copyresource) (& then reading it).

<hr>

## Drawbacks

- Two copies of `ID3D11Texture2D`s are created for each video output.
- A copy (though, GPU to GPU) is involved. Technically there should be a slight affect in performance.

Personally, I can't notice any difference performance-wise even on my slow machine, so I believe it is negligible. Since, we were using a long trail of `glFinish` already, I think this is already better & more stable solution for the future of the project.

## Advantages

- Better synchronization between libmpv & Flutter rendering. 
- No multiple `glFinish` calls between each frame.


As last pull request (#27) introduced a new synchronization mechanism i.e. `ThreadPool`, a large number of issues were solved & major part of implementation was decoupled from Flutter's own rendering cycle. So, I could make [package:media_kit](https://github.com/alexmercerind/media_kit) work with stable channel of Flutter 3.3.x (stable).

- Support for Flutter 3.3.x (stable).