### PR TITLE
build(win32): bump libmpv in package:media_kit_libs_windows_video

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           channel: "stable"
       - run: flutter pub get
       - run: flutter build windows --verbose
-      - run: cmake -E tar "cfv" "media_kit_test_win32_x64.7z" --format=7zip "media_kit_test\build\windows\runner\Release"
+      - run: cmake -E tar "cfv" "media_kit_test_win32_x64.7z" --format=7zip "build\windows\runner\Release"
       - uses: actions/upload-artifact@v1
         with:
           name: media_kit_test_win32_x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,16 @@ jobs:
           channel: "stable"
       - run: flutter pub get
       - run: flutter build windows --verbose
+      - run: cmake -E tar "cfv" "media_kit_test_win32_x64.7z" --format=7zip "media_kit_test\build\windows\runner\Release"
       - uses: actions/upload-artifact@v1
         with:
-          name: media_kit_test
-          path: media_kit_test/build/windows/runner/Release
+          name: media_kit_test_win32_x64
+          path: media_kit_test_win32_x64.7z
+      - uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          prerelease: false
+          tag_name: "vnext"
+          files: |
+            media_kit_test_win32_x64.7z
+          token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,12 @@ jobs:
       - uses: actions/upload-artifact@v1
         with:
           name: media_kit_test_win32_x64
-          path: media_kit_test_win32_x64.7z
+          path: media_kit_test/media_kit_test_win32_x64.7z
       - uses: softprops/action-gh-release@v1
         with:
           draft: true
           prerelease: false
           tag_name: "vnext"
           files: |
-            media_kit_test_win32_x64.7z
+            media_kit_test/media_kit_test_win32_x64.7z
           token: ${{ secrets.ACCESS_TOKEN }}

--- a/media_kit/lib/src/libmpv/core/native_library.dart
+++ b/media_kit/lib/src/libmpv/core/native_library.dart
@@ -26,42 +26,54 @@ abstract class NativeLibrary {
     if (path != null) {
       return path;
     }
+    return (_resolved ??= await _search());
+  }
+
+  /// Searches the native shared library.
+  static Future<String> _search() async {
+    print('🎊🎊🎊');
     final scriptDir = File(Platform.script.toFilePath()).parent.path;
     final executableDir = File(Platform.resolvedExecutable).parent.path;
     if (Platform.isWindows) {
-      if (await File(join(scriptDir, kWindowsNativeLibrary)).exists()) {
-        return join(scriptDir, kWindowsNativeLibrary);
-      }
-      if (await File(join(executableDir, kWindowsNativeLibrary)).exists()) {
-        return join(executableDir, kWindowsNativeLibrary);
+      for (final library in _kWindowsNativeLibraries) {
+        if (await File(join(scriptDir, library)).exists()) {
+          return join(scriptDir, library);
+        }
+        if (await File(join(executableDir, library)).exists()) {
+          return join(executableDir, library);
+        }
       }
       // Check for `MPV_PATH` environment variable & system `PATH`.
       final mpvPath = Platform.environment['MPV_PATH'];
       final envPath = Platform.environment['PATH'];
       if (mpvPath != null) {
-        if (await File(join(mpvPath, kWindowsNativeLibrary)).exists()) {
-          return join(mpvPath, kWindowsNativeLibrary);
+        for (final library in _kWindowsNativeLibraries) {
+          if (await File(join(mpvPath, library)).exists()) {
+            return join(mpvPath, library);
+          }
         }
       }
       if (envPath != null) {
         final paths = envPath.split(';');
         for (var path in paths) {
-          if (await File(join(path, kWindowsNativeLibrary)).exists()) {
-            return join(path, kWindowsNativeLibrary);
+          for (final library in _kWindowsNativeLibraries) {
+            if (await File(join(path, library)).exists()) {
+              return join(path, library);
+            }
           }
         }
       }
-      throw Exception(kWindowsNativeLibraryNotFoundMessage);
+      throw Exception(_kWindowsNativeLibraryNotFoundMessage);
     }
     if (Platform.isLinux) {
-      if (await File(join(scriptDir, kLinuxNativeLibrary)).exists()) {
-        return join(scriptDir, kLinuxNativeLibrary);
+      if (await File(join(scriptDir, _kLinuxNativeLibrary)).exists()) {
+        return join(scriptDir, _kLinuxNativeLibrary);
       }
-      if (await File(join(executableDir, kLinuxNativeLibrary)).exists()) {
-        return join(executableDir, kLinuxNativeLibrary);
+      if (await File(join(executableDir, _kLinuxNativeLibrary)).exists()) {
+        return join(executableDir, _kLinuxNativeLibrary);
       }
       // Check for globally accessible shared libraries.
-      final systemPaths = [
+      final system = [
         // For Debian or Ubuntu based distributions.
         '/usr/lib/x86_64-linux-gnu',
         // For Arch Linux based distributions.
@@ -69,29 +81,36 @@ abstract class NativeLibrary {
         // For Fedora based distributions.
         '/usr/lib64',
       ];
-      for (final path in systemPaths) {
-        if (await File(join(path, kLinuxNativeLibrary)).exists()) {
-          return join(path, kLinuxNativeLibrary);
+      for (final path in system) {
+        if (await File(join(path, _kLinuxNativeLibrary)).exists()) {
+          return join(path, _kLinuxNativeLibrary);
         }
       }
-      throw Exception(kLinuxNativeLibraryNotFoundMessage);
+      throw Exception(_kLinuxNativeLibraryNotFoundMessage);
     }
     throw Exception(
       'NativeLibrary.find is not supported on ${Platform.operatingSystem}.',
     );
   }
 
-  /// Default `libmpv` shared library name on Windows.
-  static const String kWindowsNativeLibrary = 'mpv-2.dll';
+  /// Resolved path of the native shared library.
+  static String? _resolved;
 
-  /// Default `libmpv` shared library name on Linux.
-  static const String kLinuxNativeLibrary = 'libmpv.so';
+  /// Default libmpv shared library names on Windows.
+  static const List<String> _kWindowsNativeLibraries = [
+    'libmpv-2.dll',
+    'mpv-2.dll',
+    'mpv-1.dll',
+  ];
+
+  /// Default libmpv shared library name on Linux.
+  static const String _kLinuxNativeLibrary = 'libmpv.so';
 
   /// [Exception] message thrown when the native library is not found on Windows.
-  static const String kWindowsNativeLibraryNotFoundMessage =
+  static const String _kWindowsNativeLibraryNotFoundMessage =
       'Cannot find mpv-2.dll in your system %PATH%. One way to deal with this is to ship mpv-2.dll with your script or compiled executable in the same directory.';
 
   /// [Exception] message thrown when the native library is not found on Linux.
-  static const String kLinuxNativeLibraryNotFoundMessage =
+  static const String _kLinuxNativeLibraryNotFoundMessage =
       'Cannot find libmpv in the usual places. Depending on your distro, you may try installing mpv-devel or libmpv-dev package.';
 }

--- a/media_kit/lib/src/libmpv/core/native_library.dart
+++ b/media_kit/lib/src/libmpv/core/native_library.dart
@@ -31,7 +31,6 @@ abstract class NativeLibrary {
 
   /// Searches the native shared library.
   static Future<String> _search() async {
-    print('🎊🎊🎊');
     final scriptDir = File(Platform.script.toFilePath()).parent.path;
     final executableDir = File(Platform.resolvedExecutable).parent.path;
     if (Platform.isWindows) {

--- a/media_kit_libs_windows_audio/analysis_options.yaml
+++ b/media_kit_libs_windows_audio/analysis_options.yaml
@@ -1,4 +1,0 @@
-include: package:flutter_lints/flutter.yaml
-
-# Additional information about this file can be found at
-# https://dart.dev/guides/language/analysis-options

--- a/media_kit_libs_windows_audio/windows/CMakeLists.txt
+++ b/media_kit_libs_windows_audio/windows/CMakeLists.txt
@@ -37,7 +37,7 @@ if(NOT EXISTS "${LIBMPV_SRC}")
   add_custom_target("${PROJECT_NAME}_LIBMPV_EXTRACT" ALL)
   add_custom_command(
     TARGET "${PROJECT_NAME}_LIBMPV_EXTRACT"
-    COMMAND "${CMAKE_COMMAND}" -E tar xzf "${LIBMPV_ARCHIVE}"
+    COMMAND "${CMAKE_COMMAND}" -E tar xzf "\"${LIBMPV_ARCHIVE}\""
     WORKING_DIRECTORY "${LIBMPV_SRC}"
   )
 endif()

--- a/media_kit_libs_windows_video/analysis_options.yaml
+++ b/media_kit_libs_windows_video/analysis_options.yaml
@@ -1,4 +1,0 @@
-include: package:flutter_lints/flutter.yaml
-
-# Additional information about this file can be found at
-# https://dart.dev/guides/language/analysis-options

--- a/media_kit_libs_windows_video/windows/CMakeLists.txt
+++ b/media_kit_libs_windows_video/windows/CMakeLists.txt
@@ -4,11 +4,11 @@ set(PROJECT_NAME "media_kit_libs_windows_video")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
 # libmpv archive containing the pre-built shared libraries & headers.
-set(LIBMPV "mpv-dev-x86_64-20230116-git-50169e0.7z")
+set(LIBMPV "mpv-dev-x86_64-20230201-git-7990dd8.7z")
 
 # Download URL & MD5 hash of the libmpv archive.
-set(LIBMPV_URL "https://github.com/alexmercerind/mpv-win32-build/releases/download/2023-01-16/${LIBMPV}")
-set(LIBMPV_MD5 "b05146e43a9c47a30d551f0ad57788cc")
+set(LIBMPV_URL "https://github.com/alexmercerind/mpv-win32-build/releases/download/2023-02-01/${LIBMPV}")
+set(LIBMPV_MD5 "f74bc12679a6ab2b800500ee6567bc6f")
 
 # Download location of the libmpv archive.
 set(LIBMPV_ARCHIVE "${CMAKE_BINARY_DIR}/${LIBMPV}")
@@ -37,7 +37,10 @@ if(NOT EXISTS "${LIBMPV_SRC}")
   add_custom_target("${PROJECT_NAME}_LIBMPV_EXTRACT" ALL)
   add_custom_command(
     TARGET "${PROJECT_NAME}_LIBMPV_EXTRACT"
-    COMMAND "${CMAKE_COMMAND}" -E tar xzf "${LIBMPV_ARCHIVE}"
+    COMMAND "${CMAKE_COMMAND}" -E tar xzf "\"${LIBMPV_ARCHIVE}\""
+    COMMAND xcopy "\"${LIBMPV_SRC}/include/mpv\"" "\"${LIBMPV_SRC}/mpv\"" /E /H /C /I
+    COMMAND rmdir "\"${LIBMPV_SRC}/include\"" /S /Q
+    COMMAND ren "\"${LIBMPV_SRC}/mpv\"" "\"include\""
     WORKING_DIRECTORY "${LIBMPV_SRC}"
   )
 endif()
@@ -76,14 +79,14 @@ if(NOT EXISTS "${ANGLE_SRC}")
   add_custom_target("${PROJECT_NAME}_ANGLE_EXTRACT" ALL)
   add_custom_command(
     TARGET "${PROJECT_NAME}_ANGLE_EXTRACT"
-    COMMAND "${CMAKE_COMMAND}" -E tar xzf "${ANGLE_ARCHIVE}"
+    COMMAND "${CMAKE_COMMAND}" -E tar xzf "\"${ANGLE_ARCHIVE}\""
     WORKING_DIRECTORY "${ANGLE_SRC}"
   )
 endif()
 
 set(
   media_kit_libs_windows_video_bundled_libraries
-  "${LIBMPV_SRC}/mpv-2.dll"
+  "${LIBMPV_SRC}/libmpv-2.dll"
   "${ANGLE_SRC}/api-ms-win-core-console-l1-1-0.dll"
   "${ANGLE_SRC}/api-ms-win-core-console-l1-2-0.dll"
   "${ANGLE_SRC}/api-ms-win-core-datetime-l1-1-0.dll"

--- a/media_kit_test/lib/main.dart
+++ b/media_kit_test/lib/main.dart
@@ -1017,7 +1017,7 @@ class MultiplePlayersMultipleVideosTabsScreen extends StatelessWidget {
                 tabs: [
                   for (int i = 0; i < count; i++)
                     Tab(
-                      text: i.toString(),
+                      text: 'video_$i.mp4',
                     ),
                 ],
               ),


### PR DESCRIPTION
- Update libmpv in package:media_kit_libs_windows_video to merge latest changes at [mpv-player/mpv](https://github.com/mpv-player/mpv).
- libmpv dynamic library now uses name libmpv-2.dll on Windows.
  The the relevant libmpv.dll.a links to libmpv-2.dll (previously mpv-2.dll). Thus, we needed update.
- Now DynamicLibrary.find caches the resolved dynamic library path.