### PR TITLE
package:media_kit_native_event_loop

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "media_kit_native_event_loop/src/dart_api"]
-	path = media_kit_native_event_loop/src/dart_api
-	url = https://github.com/alexmercerind/dart_api.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "media_kit_native_event_loop/src/dart_api"]
+	path = media_kit_native_event_loop/src/dart_api
+	url = https://github.com/alexmercerind/dart_api.git

--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ class MyScreenState extends State<MyScreen> {
 }
 ```
 
+### Performance
+
+Although [package:media_kit](https://github.com/alexmercerind/media_kit) is already fairly performant, by following ways:
+
 **Note**
 
 - You can limit size of the video output by specifying `width` & `height`.
@@ -199,6 +203,19 @@ final controller = await VideoController.create(
 final controller = await VideoController.create(
   player.handle,
   enableHardwareAcceleration: false,            // default: true
+);
+```
+
+**Note**
+
+- You can disable event callbacks for a `Player` & save yourself few CPU cycles.
+- By default, `events` is `true` i.e. event streams & states are updated.
+
+```dart
+final player = Player(
+  configuration: PlayerConfiguration(
+    events: false,                              // default: true
+  ),
 );
 ```
 
@@ -226,14 +243,6 @@ dependencies:
 System shared libraries from distribution specific user-installed packages are used by-default. You can install these as follows.
 
 #### Ubuntu / Debian
-
-**On user machine you need:**
-
-```bash
-sudo apt install libmpv2
-```
-
-**On development machine you need:**
 
 ```bash
 sudo apt install libmpv-dev mpv

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ class MyScreenState extends State<MyScreen> {
 
 ### Performance
 
-Although [package:media_kit](https://github.com/alexmercerind/media_kit) is already fairly performant, by following ways:
+Although [package:media_kit](https://github.com/alexmercerind/media_kit) is already fairly performant, you can further optimize things as follows:
 
 **Note**
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,14 @@ Add in your `pubspec.yaml`:
 ```yaml
 dependencies:
   media_kit: ^0.0.1
-  # For video support.
+  # For video rendering.
   media_kit_video: ^0.0.1
+  # For enabling support for more than 8 simultaneous players (only Flutter).
+  media_kit_native_event_loop: ^1.0.0
   # Pick based on your requirements / platform:
-  media_kit_libs_windows_video: ^1.0.0 # Windows package for video (& audio) native libraries.
-  media_kit_libs_windows_audio: ^1.0.0 # Windows package for audio (only) native libraries.
-  media_kit_libs_linux: ^1.0.0 # Linux dependency package.
+  media_kit_libs_windows_video: ^1.0.0          # Windows package for video (& audio) native libraries.
+  media_kit_libs_windows_audio: ^1.0.0          # Windows package for audio (only) native libraries.
+  media_kit_libs_linux: ^1.0.0                  # Linux dependency package.
 ```
 
 ## Platforms

--- a/media_kit/README.md
+++ b/media_kit/README.md
@@ -46,7 +46,7 @@ dependencies:
 | Platform | Audio | Video |
 | -------- | ----- | ----- |
 | Windows  | Ready | Ready |
-| Linux    | Ready | WIP   |
+| Linux    | Ready | Ready |
 | macOS    | WIP   | WIP   |
 | Android  | WIP   | WIP   |
 | iOS      | WIP   | WIP   |
@@ -181,6 +181,10 @@ final controller = await VideoController.create(
 );
 ```
 
+### Performance
+
+Although [package:media_kit](https://github.com/alexmercerind/media_kit) is already fairly performant, by following ways:
+
 **Note**
 
 - You can limit size of the video output by specifying `width` & `height`.
@@ -203,6 +207,19 @@ final controller = await VideoController.create(
 final controller = await VideoController.create(
   player.handle,
   enableHardwareAcceleration: false,            // default: true
+);
+```
+
+**Note**
+
+- You can disable event callbacks for a `Player` & save yourself few CPU cycles.
+- By default, `events` is `true` i.e. event streams & states are updated.
+
+```dart
+final player = Player(
+  configuration: PlayerConfiguration(
+    events: false,                              // default: true
+  ),
 );
 ```
 
@@ -231,16 +248,8 @@ System shared libraries from distribution specific user-installed packages are u
 
 #### Ubuntu / Debian
 
-**On user machine you need:**
-
 ```bash
-sudo apt install libmpv2
-```
-
-**On development machine you need:**
-
-```bash
-sudo apt install libmpv-dev libmpv2
+sudo apt install libmpv-dev mpv
 ```
 
 #### Packaging

--- a/media_kit/README.md
+++ b/media_kit/README.md
@@ -171,19 +171,9 @@ class MyScreenState extends State<MyScreen> {
 }
 ```
 
-For performance reasons (especially in S/W rendering), if you wish to restrain the size of each video frame, you can pass width & height parameters to the `VideoController.create` method.
-
-```dart
-final controller = await VideoController.create(
-  player.handle,
-  width: 1920,
-  height: 1080,
-);
-```
-
 ### Performance
 
-Although [package:media_kit](https://github.com/alexmercerind/media_kit) is already fairly performant, by following ways:
+Although [package:media_kit](https://github.com/alexmercerind/media_kit) is already fairly performant, you can further optimize things as follows:
 
 **Note**
 

--- a/media_kit/README.md
+++ b/media_kit/README.md
@@ -31,12 +31,14 @@ Add in your `pubspec.yaml`:
 ```yaml
 dependencies:
   media_kit: ^0.0.1
-  # For video support.
+  # For video rendering.
   media_kit_video: ^0.0.1
+  # For enabling support for more than 8 simultaneous players (only Flutter).
+  media_kit_native_event_loop: ^1.0.0
   # Pick based on your requirements / platform:
-  media_kit_libs_windows_video: ^1.0.0 # Windows package for video (& audio) native libraries.
-  media_kit_libs_windows_audio: ^1.0.0 # Windows package for audio (only) native libraries.
-  media_kit_libs_linux: ^1.0.0 # Linux dependency package.
+  media_kit_libs_windows_video: ^1.0.0          # Windows package for video (& audio) native libraries.
+  media_kit_libs_windows_audio: ^1.0.0          # Windows package for audio (only) native libraries.
+  media_kit_libs_linux: ^1.0.0                  # Linux dependency package.
 ```
 
 ## Platforms

--- a/media_kit/lib/src/libmpv/core/initializer.dart
+++ b/media_kit/lib/src/libmpv/core/initializer.dart
@@ -1,147 +1,25 @@
-/// This file is a part of media_kit (https://github.com/alexmercerind/media_kit).
-///
-/// Copyright © 2021 & onwards, Hitesh Kumar Saini <saini123hitesh@gmail.com>.
-/// All rights reserved.
-/// Use of this source code is governed by MIT license that can be found in the LICENSE file.
-
 import 'dart:ffi';
-import 'dart:async';
-import 'dart:isolate';
 
 import 'package:media_kit/generated/libmpv/bindings.dart';
 
-/// Detect if app running in release mode.
-const isReleaseMode = bool.fromEnvironment('dart.vm.product');
+import 'initializer_isolate.dart' as initializer_isolate;
+import 'initializer_native_event_loop.dart' as initializer_native_event_loop;
 
-/// Runs on separate isolate.
-/// Calls [MPV.mpv_create] & [MPV.mpv_initialize] to create a new [mpv_handle].
-/// Uses [MPV.mpv_wait_event] to wait for the next event & notifies through the passed [SendPort] as the argument.
-///
-/// First value sent through the [SendPort] is [SendPort] of the internal [ReceivePort].
-/// Second value sent through the [SendPort] is raw address of the [Pointer] to [mpv_handle] created by the isolate.
-/// Subsequent sent values are [Pointer] to [mpv_event].
-///
-void mainloop(SendPort port) async {
-  /// Used to ensure that the last [mpv_event] is NOT reset to [mpv_event_id.MPV_EVENT_NONE] after waiting using [MPV.mpv_wait_event] again in the continuously running while loop.
-  var completer = Completer();
-
-  /// Used to recieve the confirmation messages from the main thread about successful receive of the sent event through [SendPort].
-  /// Upon confirmation, the [Completer] is completed & we jump to next iteration of the while loop waiting with [MPV.mpv_wait_event].
-  var receiver = ReceivePort();
-
-  /// Send the [SendPort] of internal [ReceivePort].
-  port.send(receiver.sendPort);
-
-  /// Separately creating [MPV] object since isolates don't share variables.
-  late MPV mpv;
-
-  receiver.listen((message) {
-    if (message is String) {
-      /// Initializing the local [MPV] object.
-      mpv = MPV(DynamicLibrary.open(message));
-    }
-
-    /// Notifying about the successful sending of the event & move onto next [MPV.mpv_wait_event] after completing the [Completer].
-    completer.complete();
-  });
-
-  /// Waiting for [MPV] to be late initialized.
-  await completer.future;
-
-  /// Creating & initializing [mpv_handle].
-  var handle = mpv.mpv_create();
-  mpv.mpv_initialize(handle);
-
-  /// Sending the address of the created [mpv_handle] & the [SendPort] of the [receivePort].
-  /// Raw address is sent as [int] since we cannot transfer objects through Native Ports, only primatives.
-  port.send(handle.address);
-
-  /// Lookup for events & send to main thread through [SendPort].
-  /// Ensuring the successful sending of the last event before moving to next [MPV.mpv_wait_event].
-  while (true) {
-    completer = Completer();
-    Pointer<mpv_event> event =
-        mpv.mpv_wait_event(handle, isReleaseMode ? -1 : 0.1);
-
-    /// Sending raw address of [mpv_event].
-    port.send(event.address);
-
-    /// Ensuring that the last [mpv_event] (which is at the same address) is NOT reset to [mpv_event_id.MPV_EVENT_NONE] after next [MPV.mpv_wait_event] in the loop.
-    await completer.future;
-    if (event.ref.event_id == mpv_event_id.MPV_EVENT_SHUTDOWN) {
-      break;
-    }
-  }
-}
-
-/// Creates & returns [Pointer] to [mpv_handle] whose event loop is running on separate isolate.
-///
+/// Creates & returns initialized [Pointer] to [mpv_handle].
 /// Pass [path] to libmpv dynamic library & [callback] to receive event callbacks as [Pointer] to [mpv_event].
+///
+/// Platform specific threaded event loop is preferred over [Isolate] based event loop (automatic fallback).
+/// See package:media_kit_native_event_loop for more details.
+///
 Future<Pointer<mpv_handle>> create(
   String path,
   Future<void> Function(Pointer<mpv_event> event) callback,
 ) async {
-  /// Used to wait for retrieval of [Pointer] to [mpv_handle] from the running isolate.
-  var completer = Completer();
-
-  /// Used to receive events from the separate isolate.
-  var receiver = ReceivePort();
-
-  /// Late initialized [mpv_handle] & [SendPort] of the [ReceievePort] inside the separate isolate.
-  late Pointer<mpv_handle> handle;
-  late SendPort port;
-
-  /// Run mainloop in the separate isolate.
-  Isolate.spawn(
-    mainloop,
-    receiver.sendPort,
-  );
-
-  receiver.listen((message) {
-    /// Receiving [SendPort] of the [ReceivePort] inside the separate isolate to send the path to [DynamicLibrary].
-    if (!completer.isCompleted && message is SendPort) {
-      port = message;
-      port.send(path);
-    }
-
-    /// Receiving [Pointer] to [mpv_handle] created by separate isolate.
-    else if (!completer.isCompleted && message is int) {
-      handle = Pointer.fromAddress(message);
-      completer.complete();
-    }
-
-    /// Receiving event callbacks.
-    else {
-      Pointer<mpv_event> event = Pointer.fromAddress(message);
-      silencedCallback(
-        callback,
-        event,
-      ).then((value) {
-        /// Sending the confirmation.
-        port.send(null);
-      });
-    }
-  });
-
-  /// Awaiting the retrieval of [Pointer] to [mpv_handle].
-  await completer.future;
-  return handle;
-}
-
-/// I cannot afford to crash the whole [Isolate].
-/// This will prevent event handling from being stopped due to some random unhandled exception in the passed [callback] by [Player] pr [Tagger].
-///
-Future<void> silencedCallback(
-  Future<void> Function(Pointer<mpv_event> event) callback,
-  Pointer<mpv_event> event,
-) async {
   try {
-    await callback(event);
+    return await initializer_native_event_loop.create(path, callback);
   } catch (exception, stacktrace) {
-    print(
-      'package:media_kit/src/core/initializer.dart: received exception in passed [create] [callback].',
-    );
-    print(exception.toString());
-    print(stacktrace.toString());
+    print(exception);
+    print(stacktrace);
+    return await initializer_isolate.create(path, callback);
   }
 }

--- a/media_kit/lib/src/libmpv/core/initializer.dart
+++ b/media_kit/lib/src/libmpv/core/initializer.dart
@@ -13,7 +13,7 @@ import 'initializer_native_event_loop.dart' as initializer_native_event_loop;
 ///
 Future<Pointer<mpv_handle>> create(
   String path,
-  Future<void> Function(Pointer<mpv_event> event) callback,
+  Future<void> Function(Pointer<mpv_event> event)? callback,
 ) async {
   try {
     return await initializer_native_event_loop.create(path, callback);

--- a/media_kit/lib/src/libmpv/core/initializer_isolate.dart
+++ b/media_kit/lib/src/libmpv/core/initializer_isolate.dart
@@ -1,0 +1,110 @@
+/// This file is a part of media_kit (https://github.com/alexmercerind/media_kit).
+///
+/// Copyright © 2021 & onwards, Hitesh Kumar Saini <saini123hitesh@gmail.com>.
+/// All rights reserved.
+/// Use of this source code is governed by MIT license that can be found in the LICENSE file.
+
+import 'dart:ffi';
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:media_kit/generated/libmpv/bindings.dart';
+
+/// Detect if app running in release mode.
+const isReleaseMode = bool.fromEnvironment('dart.vm.product');
+
+/// Runs on separate isolate.
+/// Calls [MPV.mpv_create] & [MPV.mpv_initialize] to create a new [mpv_handle].
+/// Uses [MPV.mpv_wait_event] to wait for the next event & notifies through the passed [SendPort] as the argument.
+///
+/// First value sent through the [SendPort] is [SendPort] of the internal [ReceivePort].
+/// Second value sent through the [SendPort] is raw address of the [Pointer] to [mpv_handle] created by the isolate.
+/// Subsequent sent values are [Pointer] to [mpv_event].
+///
+void mainloop(SendPort port) async {
+  // Used to ensure that the last [mpv_event] is NOT reset to [mpv_event_id.MPV_EVENT_NONE] after waiting using [MPV.mpv_wait_event] again in the continuously running while loop.
+  var completer = Completer();
+  // Used to recieve the confirmation messages from the main thread about successful receive of the sent event through [SendPort].
+  // Upon confirmation, the [Completer] is completed & we jump to next iteration of the while loop waiting with [MPV.mpv_wait_event].
+  final receiver = ReceivePort();
+  // Send the [SendPort] of internal [ReceivePort].
+  port.send(receiver.sendPort);
+  // Separately creating [MPV] object since isolates don't share finaliables.
+  late MPV mpv;
+  receiver.listen((message) {
+    if (message is String) {
+      // Initializing the local [MPV] object.
+      mpv = MPV(DynamicLibrary.open(message));
+    }
+    // Notifying about the successful sending of the event & move onto next [MPV.mpv_wait_event] after completing the [Completer].
+    completer.complete();
+  });
+  // Waiting for [MPV] to be late initialized.
+  await completer.future;
+  // Creating & initializing [mpv_handle].
+  final handle = mpv.mpv_create();
+  mpv.mpv_initialize(handle);
+  // Sending the address of the created [mpv_handle] & the [SendPort] of the [receivePort].
+  // Raw address is sent as [int] since we cannot transfer objects through Native Ports, only primatives.
+  port.send(handle.address);
+  // Lookup for events & send to main thread through [SendPort].
+  // Ensuring the successful sending of the last event before moving to next [MPV.mpv_wait_event].
+  while (true) {
+    completer = Completer();
+    final event = mpv.mpv_wait_event(handle, isReleaseMode ? -1 : 0.1);
+    // Sending raw address of [mpv_event].
+    port.send(event.address);
+    // Ensuring that the last [mpv_event] (which is at the same address) is NOT reset to [mpv_event_id.MPV_EVENT_NONE] after next [MPV.mpv_wait_event] in the loop.
+    await completer.future;
+    if (event.ref.event_id == mpv_event_id.MPV_EVENT_SHUTDOWN) {
+      break;
+    }
+  }
+}
+
+/// Creates & returns initialized [Pointer] to [mpv_handle] whose event loop is running on separate isolate.
+///
+/// Pass [path] to libmpv dynamic library & [callback] to receive event callbacks as [Pointer] to [mpv_event].
+Future<Pointer<mpv_handle>> create(
+  String path,
+  Future<void> Function(Pointer<mpv_event> event) callback,
+) async {
+  // Used to wait for retrieval of [Pointer] to [mpv_handle] from the running isolate.
+  final completer = Completer();
+  // Used to receive events from the separate isolate.
+  final receiver = ReceivePort();
+  // Late initialized [mpv_handle] & [SendPort] of the [ReceievePort] inside the separate isolate.
+  late Pointer<mpv_handle> handle;
+  late SendPort port;
+  // Run mainloop in the separate isolate.
+  await Isolate.spawn(
+    mainloop,
+    receiver.sendPort,
+  );
+  receiver.listen((message) async {
+    // Receiving [SendPort] of the [ReceivePort] inside the separate isolate to send the path to [DynamicLibrary].
+    if (!completer.isCompleted && message is SendPort) {
+      port = message;
+      port.send(path);
+    }
+    // Receiving [Pointer] to [mpv_handle] created by separate isolate.
+    else if (!completer.isCompleted && message is int) {
+      handle = Pointer.fromAddress(message);
+      completer.complete();
+    }
+    // Receiving event callbacks.
+    else {
+      Pointer<mpv_event> event = Pointer.fromAddress(message);
+      try {
+        await callback(event);
+      } catch (exception, stacktrace) {
+        print(exception.toString());
+        print(stacktrace.toString());
+      }
+      port.send(null);
+    }
+  });
+  // Awaiting the retrieval of [Pointer] to [mpv_handle].
+  await completer.future;
+  return handle;
+}

--- a/media_kit/lib/src/libmpv/core/initializer_native_event_loop.dart
+++ b/media_kit/lib/src/libmpv/core/initializer_native_event_loop.dart
@@ -1,0 +1,149 @@
+/// This file is a part of media_kit (https://github.com/alexmercerind/media_kit).
+///
+/// Copyright © 2021 & onwards, Hitesh Kumar Saini <saini123hitesh@gmail.com>.
+/// All rights reserved.
+/// Use of this source code is governed by MIT license that can be found in the LICENSE file.
+
+// ignore_for_file: non_constant_identifier_names, unused_local_variable, camel_case_types
+
+import 'dart:io';
+import 'dart:ffi';
+import 'dart:async';
+import 'dart:isolate';
+import 'dart:collection';
+
+import 'package:media_kit/generated/libmpv/bindings.dart';
+
+/// Name of the shared library used for platform specific threaded event handling.
+///
+/// See:
+/// https://github.com/alexmercerind/media_kit/issues/40
+/// https://github.com/alexmercerind/media_kit/pull/46
+/// https://github.com/dart-lang/sdk/issues/51254
+/// https://github.com/dart-lang/sdk/issues/51261
+const kNativeEventLoopDynamicLibrary = 'media_kit_native_event_loop';
+
+// Type definitions for native functions in the shared library.
+
+// C/C++:
+
+typedef Dart_InitializeApiDLCXX = Void Function(Pointer<Void> data);
+typedef MediaKitEventLoopHandlerRegisterCXX = Void Function(
+  Int64 handle,
+  Pointer<Void> callback,
+  Int64 port,
+);
+
+// Dart:
+
+typedef MediaKitEventLoopHandlerNotifyCXX = Void Function(Int64 handle);
+typedef Dart_InitializeApiDLDart = void Function(Pointer<Void> data);
+typedef MediaKitEventLoopHandlerRegisterDart = void Function(
+  int handle,
+  Pointer<Void> callback,
+  int port,
+);
+typedef MediaKitEventLoopHandlerNotifyDart = void Function(int handle);
+
+// Resolved native functions from the shared library.
+Dart_InitializeApiDLDart? Dart_InitializeApiDL;
+MediaKitEventLoopHandlerRegisterDart? MediaKitEventLoopHandlerRegister;
+MediaKitEventLoopHandlerNotifyDart? MediaKitEventLoopHandlerNotify;
+
+// Registered [callback]s to receive [mpv_event](s) from the native event loop.
+final callbacks = HashMap<int, Future<void> Function(Pointer<mpv_event>)>();
+
+/// [ReceivePort] used to listen for `mpv_event`(s) from the native event loop.
+/// A single [ReceivePort] is used for multiple instances.
+final receiver = ReceivePort()
+  ..listen(
+    (dynamic message) async {
+      try {
+        final handle = message[0] as int;
+        final event = Pointer<mpv_event>.fromAddress(message[1]);
+        if (event.ref.event_id == mpv_event_id.MPV_EVENT_SHUTDOWN) {
+          callbacks.remove(handle);
+        } else {
+          // Notify public event handler.
+          await callbacks[handle]?.call(event);
+        }
+      } catch (exception, stacktrace) {
+        print(exception);
+        print(stacktrace);
+      }
+      // Notify native event loop that event has been handled & it is safe to move onto next `mpv_wait_event`.
+      MediaKitEventLoopHandlerNotify?.call(message[0]);
+    },
+  );
+
+/// Creates & returns initialized [Pointer] to [mpv_handle] whose event loop is running on native thread.
+///
+/// Pass [path] to libmpv dynamic library & [callback] to receive event callbacks as [Pointer] to [mpv_event].
+Future<Pointer<mpv_handle>> create(
+  String path,
+  Future<void> Function(Pointer<mpv_event> event) callback,
+) async {
+  // Load native functions from the shared library on first call.
+  if (Dart_InitializeApiDL == null &&
+      MediaKitEventLoopHandlerRegister == null &&
+      MediaKitEventLoopHandlerNotify == null) {
+    final dylib = () {
+      if (Platform.isMacOS || Platform.isIOS) {
+        return DynamicLibrary.open(
+          '$kNativeEventLoopDynamicLibrary.framework/$kNativeEventLoopDynamicLibrary',
+        );
+      }
+      if (Platform.isAndroid || Platform.isLinux) {
+        return DynamicLibrary.open('lib$kNativeEventLoopDynamicLibrary.so');
+      }
+      if (Platform.isWindows) {
+        return DynamicLibrary.open('$kNativeEventLoopDynamicLibrary.dll');
+      }
+    }();
+    if (dylib != null) {
+      // Load native functions from the dynamic library.
+      Dart_InitializeApiDL = dylib.lookupFunction<Dart_InitializeApiDLCXX,
+          Dart_InitializeApiDLDart>('Dart_InitializeApiDL');
+      MediaKitEventLoopHandlerRegister = dylib.lookupFunction<
+          MediaKitEventLoopHandlerRegisterCXX,
+          MediaKitEventLoopHandlerRegisterDart>(
+        'MediaKitEventLoopHandlerRegister',
+      );
+      MediaKitEventLoopHandlerNotify = dylib.lookupFunction<
+          MediaKitEventLoopHandlerNotifyCXX,
+          MediaKitEventLoopHandlerNotifyDart>(
+        'MediaKitEventLoopHandlerNotify',
+      );
+
+      // Initialize dart_api_dl.h.
+      Dart_InitializeApiDL?.call(NativeApi.initializeApiDLData);
+    }
+  }
+  // Native functions from the shared library should be resolved by now.
+  // If not, throw an exception.
+  // Primarily, this will happen when the shared library is not found i.e. package:media_kit_native_event_loop is not installed.
+  if (Dart_InitializeApiDL == null ||
+      MediaKitEventLoopHandlerRegister == null ||
+      MediaKitEventLoopHandlerNotify == null) {
+    throw Exception(
+      'package:media_kit/src/core/initializer_event_loop.dart: Unable to find native event loop shared library.',
+    );
+  }
+
+  // Create [mpv_handle] & initialize it.
+  final mpv = MPV(DynamicLibrary.open(path));
+  final handle = mpv.mpv_create();
+  mpv.mpv_initialize(handle);
+
+  // Save [callback] to invoke it inside [ReceivePort] listener.
+  callbacks[handle.address] = callback;
+
+  // Register event callback.
+  MediaKitEventLoopHandlerRegister?.call(
+    handle.address,
+    NativeApi.postCObject.cast(),
+    receiver.sendPort.nativePort,
+  );
+
+  return handle;
+}

--- a/media_kit/lib/src/platform_player.dart
+++ b/media_kit/lib/src/platform_player.dart
@@ -24,6 +24,10 @@ import 'package:media_kit/src/models/player_streams.dart';
 ///
 /// {@endtemplate}
 class PlayerConfiguration {
+  /// Enables or disables event handling. This may improve performance if there is no need to listen to events.
+  /// Default: `true`.
+  final bool events;
+
   /// Enables on-screen libmpv controls.
   ///
   /// Default: `false`.
@@ -54,6 +58,7 @@ class PlayerConfiguration {
 
   /// {@macro player_configuration}
   const PlayerConfiguration({
+    this.events = true,
     this.osc = false,
     this.vid,
     this.vo,

--- a/media_kit_native_event_loop/.metadata
+++ b/media_kit_native_event_loop/.metadata
@@ -4,8 +4,8 @@
 # This file should be version controlled.
 
 version:
-  revision: 7048ed95a5ad3e43d697e0c397464193991fc230
-  channel: stable
+  revision: 0be7c3f30d647423e3bec24ebbb5f89e03e79b96
+  channel: master
 
 project_type: plugin_ffi
 
@@ -13,11 +13,14 @@ project_type: plugin_ffi
 migration:
   platforms:
     - platform: root
-      create_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
-      base_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
+      create_revision: 0be7c3f30d647423e3bec24ebbb5f89e03e79b96
+      base_revision: 0be7c3f30d647423e3bec24ebbb5f89e03e79b96
+    - platform: linux
+      create_revision: 0be7c3f30d647423e3bec24ebbb5f89e03e79b96
+      base_revision: 0be7c3f30d647423e3bec24ebbb5f89e03e79b96
     - platform: windows
-      create_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
-      base_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
+      create_revision: 0be7c3f30d647423e3bec24ebbb5f89e03e79b96
+      base_revision: 0be7c3f30d647423e3bec24ebbb5f89e03e79b96
 
   # User provided section
 

--- a/media_kit_native_event_loop/.metadata
+++ b/media_kit_native_event_loop/.metadata
@@ -15,6 +15,9 @@ migration:
     - platform: root
       create_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
       base_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
+    - platform: windows
+      create_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
+      base_revision: 7048ed95a5ad3e43d697e0c397464193991fc230
 
   # User provided section
 

--- a/media_kit_native_event_loop/linux/CMakeLists.txt
+++ b/media_kit_native_event_loop/linux/CMakeLists.txt
@@ -1,0 +1,17 @@
+# This file is a part of media_kit (https://github.com/alexmercerind/media_kit).
+#
+# Copyright © 2021 & onwards, Hitesh Kumar Saini <saini123hitesh@gmail.com>.
+# All rights reserved.
+# Use of this source code is governed by MIT license that can be found in the LICENSE file.
+
+cmake_minimum_required(VERSION 3.10)
+
+set(PROJECT_NAME "media_kit_native_event_loop")
+project(${PROJECT_NAME} LANGUAGES CXX)
+
+add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../src" "${CMAKE_CURRENT_BINARY_DIR}/shared")
+
+set(media_kit_native_event_loop_bundled_libraries
+  $<TARGET_FILE:media_kit_native_event_loop>
+  PARENT_SCOPE
+)

--- a/media_kit_native_event_loop/pubspec.yaml
+++ b/media_kit_native_event_loop/pubspec.yaml
@@ -19,3 +19,5 @@ flutter:
     platforms:
       windows:
         ffiPlugin: true
+      linux:
+        ffiPlugin: true

--- a/media_kit_native_event_loop/src/CMakeLists.txt
+++ b/media_kit_native_event_loop/src/CMakeLists.txt
@@ -17,7 +17,6 @@ project(
 add_library(
   ${TARGET_NAME} SHARED
   "${TARGET_NAME}.cc"
-  "dart_api/dart_api_dl.cc"
 )
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
@@ -34,7 +33,23 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     "${LIBMPV_SRC}/libmpv.dll.a"
   )
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  # TODO: Add support for Linux.
+  # Check for libmpv & epoxy headers & libraries.
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(mpv IMPORTED_TARGET mpv)
+
+  # Include libmpv headers & link to the library.
+  target_compile_definitions(
+    ${TARGET_NAME} PRIVATE
+    "${mpv_CFLAGS_OTHER}"
+  )
+  target_include_directories(
+    ${TARGET_NAME} INTERFACE
+    "${mpv_INCLUDE_DIRS}"
+  )
+  target_link_libraries(
+    ${TARGET_NAME} PRIVATE
+    PkgConfig::mpv
+  )
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   # TODO: Add support for macOS.
 endif()

--- a/media_kit_native_event_loop/src/CMakeLists.txt
+++ b/media_kit_native_event_loop/src/CMakeLists.txt
@@ -6,20 +6,43 @@
 
 cmake_minimum_required(VERSION 3.10)
 
+set(TARGET_NAME media_kit_native_event_loop)
+set(CMAKE_CXX_STANDARD 17)
+
 project(
-  media_kit_native_event_loop_library
+  ${TARGET_NAME}_library
   VERSION 1.0.0 LANGUAGES CXX
 )
 
 add_library(
-  media_kit_native_event_loop SHARED
-  "media_kit_native_event_loop.c"
+  ${TARGET_NAME} SHARED
+  "${TARGET_NAME}.cc"
+  "dart_api/dart_api_dl.cc"
 )
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  # Set the path to libmpv & ANGLE source code.
+  # Must be built before this CMake project.
+  set(LIBMPV_SRC "${CMAKE_BINARY_DIR}/libmpv")
+
+  # Include libmpv headers & link to the library.
+  include_directories(
+    "${LIBMPV_SRC}/include"
+  )
+  target_link_libraries(
+    ${TARGET_NAME} PRIVATE
+    "${LIBMPV_SRC}/libmpv.dll.a"
+  )
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  # TODO: Add support for Linux.
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  # TODO: Add support for macOS.
+endif()
 
 set_target_properties(
-  media_kit_native_event_loop PROPERTIES
-  PUBLIC_HEADER media_kit_native_event_loop.h
-  OUTPUT_NAME "media_kit_native_event_loop"
+  ${TARGET_NAME} PROPERTIES
+  PUBLIC_HEADER ${TARGET_NAME}.h
+  OUTPUT_NAME "${TARGET_NAME}"
 )
 
-target_compile_definitions(media_kit_native_event_loop PUBLIC DART_SHARED_LIB)
+target_compile_definitions(${TARGET_NAME} PUBLIC DART_SHARED_LIB)

--- a/media_kit_native_event_loop/src/dart_api_types.h
+++ b/media_kit_native_event_loop/src/dart_api_types.h
@@ -1,0 +1,89 @@
+#ifndef DART_API_TYPES_H_
+#define DART_API_TYPES_H_
+
+#include <cstdint>
+
+// Dart API type declarations.
+
+typedef int64_t Dart_Port;
+typedef void (*Dart_HandleFinalizer)(void* isolate_callback_data, void* peer);
+
+typedef enum {
+  Dart_CObject_kNull = 0,
+  Dart_CObject_kBool,
+  Dart_CObject_kInt32,
+  Dart_CObject_kInt64,
+  Dart_CObject_kDouble,
+  Dart_CObject_kString,
+  Dart_CObject_kArray,
+  Dart_CObject_kTypedData,
+  Dart_CObject_kExternalTypedData,
+  Dart_CObject_kUnmodifiableExternalTypedData,
+  Dart_CObject_kSendPort,
+  Dart_CObject_kCapability,
+  Dart_CObject_kNativePointer,
+  Dart_CObject_kUnsupported,
+  Dart_CObject_kNumberOfTypes
+} Dart_CObject_Type;
+
+typedef enum {
+  Dart_TypedData_kByteData = 0,
+  Dart_TypedData_kInt8,
+  Dart_TypedData_kUint8,
+  Dart_TypedData_kUint8Clamped,
+  Dart_TypedData_kInt16,
+  Dart_TypedData_kUint16,
+  Dart_TypedData_kInt32,
+  Dart_TypedData_kUint32,
+  Dart_TypedData_kInt64,
+  Dart_TypedData_kUint64,
+  Dart_TypedData_kFloat32,
+  Dart_TypedData_kFloat64,
+  Dart_TypedData_kInt32x4,
+  Dart_TypedData_kFloat32x4,
+  Dart_TypedData_kFloat64x2,
+  Dart_TypedData_kInvalid
+} Dart_TypedData_Type;
+
+typedef struct _Dart_CObject {
+  Dart_CObject_Type type;
+  union {
+    bool as_bool;
+    int32_t as_int32;
+    int64_t as_int64;
+    double as_double;
+    const char* as_string;
+    struct {
+      Dart_Port id;
+      Dart_Port origin_id;
+    } as_send_port;
+    struct {
+      int64_t id;
+    } as_capability;
+    struct {
+      intptr_t length;
+      struct _Dart_CObject** values;
+    } as_array;
+    struct {
+      Dart_TypedData_Type type;
+      intptr_t length; /* in elements, not bytes */
+      const uint8_t* values;
+    } as_typed_data;
+    struct {
+      Dart_TypedData_Type type;
+      intptr_t length; /* in elements, not bytes */
+      uint8_t* data;
+      void* peer;
+      Dart_HandleFinalizer callback;
+    } as_external_typed_data;
+    struct {
+      intptr_t ptr;
+      intptr_t size;
+      Dart_HandleFinalizer callback;
+    } as_native_pointer;
+  } value;
+} Dart_CObject;
+
+typedef bool (*Dart_PostCObject)(Dart_Port port_id, Dart_CObject* message);
+
+#endif  // DART_API_TYPES_H_

--- a/media_kit_native_event_loop/src/media_kit_native_event_loop.cc
+++ b/media_kit_native_event_loop/src/media_kit_native_event_loop.cc
@@ -13,4 +13,78 @@ MediaKitEventLoopHandler& MediaKitEventLoopHandler::GetInstance() {
   return instance;
 }
 
-MediaKitEventLoopHandler::MediaKitEventLoopHandler() {}
+void MediaKitEventLoopHandler::Register(int64_t handle,
+                                        void* post_c_object,
+                                        int64_t send_port) {
+  // Only during the first call.
+  // Save references to NativeApi.postCObject & ReceivePort.sendPort.nativePort.
+  if (post_c_object_ == nullptr) {
+    post_c_object_ =
+        reinterpret_cast<bool (*)(Dart_Port, Dart_CObject*)>(post_c_object);
+  }
+  if (send_port_ == -1) {
+    send_port_ = send_port;
+  }
+
+  auto context = reinterpret_cast<mpv_handle*>(handle);
+  std::thread([this, context]() {
+    for(;;) {
+      {
+        std::lock_guard<std::mutex> lock(mutexes_[context]);
+        promises_[context] = std::promise<void>();
+      }
+
+      auto event = mpv_wait_event(context, -1);
+
+      // [mpv_handle*, mpv_event*]
+      Dart_CObject mpv_handle_object;
+      mpv_handle_object.type = Dart_CObject_kInt64;
+      mpv_handle_object.value.as_int64 = reinterpret_cast<int64_t>(context);
+      Dart_CObject mpv_event_object;
+      mpv_event_object.type = Dart_CObject_kInt64;
+      mpv_event_object.value.as_int64 = reinterpret_cast<int64_t>(event);
+      Dart_CObject* value_objects[] = {&mpv_handle_object, &mpv_event_object};
+      Dart_CObject event_object;
+      event_object.type = Dart_CObject_kArray;
+      event_object.value.as_array.length = 2;
+      event_object.value.as_array.values = value_objects;
+      // Post to Dart.
+      post_c_object_(send_port_, &event_object);
+
+      if (event->event_id == MPV_EVENT_SHUTDOWN) {
+        break;
+      }
+
+      // Interpret the event inside Dart.
+      // Wait for |MediaKitEventLoopHandler::Notify| to be called.
+      promises_[context].get_future().wait();
+    }
+  }).detach();
+}
+
+void MediaKitEventLoopHandler::Notify(int64_t handle) {
+  auto context = reinterpret_cast<mpv_handle*>(handle);
+  std::lock_guard<std::mutex> lock(mutexes_[context]);
+  // Allow next |mpv_wait_event| to be called.
+  promises_[context].set_value();
+}
+
+MediaKitEventLoopHandler::MediaKitEventLoopHandler()
+    : post_c_object_(nullptr), send_port_(-1) {}
+
+MediaKitEventLoopHandler::~MediaKitEventLoopHandler() {}
+
+// ---------------------------------------------------------------------------
+// C API for access using dart:ffi
+// ---------------------------------------------------------------------------
+
+void MediaKitEventLoopHandlerRegister(int64_t handle,
+                                      void* post_c_object,
+                                      int64_t send_port) {
+  MediaKitEventLoopHandler::GetInstance().Register(handle, post_c_object,
+                                                   send_port);
+}
+
+void MediaKitEventLoopHandlerNotify(int64_t handle) {
+  MediaKitEventLoopHandler::GetInstance().Notify(handle);
+}

--- a/media_kit_native_event_loop/src/media_kit_native_event_loop.cc
+++ b/media_kit_native_event_loop/src/media_kit_native_event_loop.cc
@@ -7,3 +7,10 @@
 // LICENSE file.
 
 #include "media_kit_native_event_loop.h"
+
+MediaKitEventLoopHandler& MediaKitEventLoopHandler::GetInstance() {
+  static MediaKitEventLoopHandler instance;
+  return instance;
+}
+
+MediaKitEventLoopHandler::MediaKitEventLoopHandler() {}

--- a/media_kit_native_event_loop/src/media_kit_native_event_loop.h
+++ b/media_kit_native_event_loop/src/media_kit_native_event_loop.h
@@ -12,11 +12,12 @@
 #ifdef _WIN32
 #include <client.h>
 #elif __linux__
-// TODO(@alexmercerind): GNU/Linux libmpv headers.
+#include <mpv/client.h>
 #elif __APPLE__
 // TODO(@alexmercerind): macOS libmpv headers.
 #endif
-#include "dart_api/dart_api_dl.h"
+
+#include "dart_api_types.h"
 
 #include <future>
 #include <functional>

--- a/media_kit_native_event_loop/src/media_kit_native_event_loop.h
+++ b/media_kit_native_event_loop/src/media_kit_native_event_loop.h
@@ -6,7 +6,34 @@
 // Use of this source code is governed by MIT license that can be found in the
 // LICENSE file.
 
-#if _WIN32
+#ifndef MEDIA_KIT_NATIVE_EVENT_LOOP_H_
+#define MEDIA_KIT_NATIVE_EVENT_LOOP_H_
+
+#ifdef _WIN32
+#include <client.h>
+#elif __linux__
+// TODO(@alexmercerind): GNU/Linux libmpv headers.
+#elif __APPLE__
+// TODO(@alexmercerind): macOS libmpv headers.
+#endif
+#include "dart_api/dart_api_dl.h"
+
+class MediaKitEventLoopHandler {
+ public:
+  static MediaKitEventLoopHandler& GetInstance();
+  MediaKitEventLoopHandler(const MediaKitEventLoopHandler&) = delete;
+  void operator=(const MediaKitEventLoopHandler&) = delete;
+
+ private:
+  MediaKitEventLoopHandler();
+  ~MediaKitEventLoopHandler() = default;
+};
+
+// ---------------------------------------------------------------------------
+// C API for access using dart:ffi
+// ---------------------------------------------------------------------------
+
+#ifdef _WIN32
 #define DLLEXPORT __declspec(dllexport)
 #else
 #define DLLEXPORT __attribute__((visibility("default")))
@@ -16,8 +43,8 @@
 extern "C" {
 #endif
 
-// TODO(@alexmercerind): Missing implementation.
-
 #ifdef __cplusplus
 }
 #endif
+
+#endif  // MEDIA_KIT_NATIVE_EVENT_LOOP_H_

--- a/media_kit_native_event_loop/windows/.gitignore
+++ b/media_kit_native_event_loop/windows/.gitignore
@@ -1,0 +1,17 @@
+flutter/
+
+# Visual Studio user-specific files.
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Visual Studio build-related files.
+x64/
+x86/
+
+# Visual Studio cache files
+# files ending in .cache can be ignored
+*.[Cc]ache
+# but keep track of directories ending in .cache
+!*.[Cc]ache/

--- a/media_kit_native_event_loop/windows/CMakeLists.txt
+++ b/media_kit_native_event_loop/windows/CMakeLists.txt
@@ -1,0 +1,21 @@
+# This file is a part of media_kit (https://github.com/alexmercerind/media_kit).
+#
+# Copyright © 2021 & onwards, Hitesh Kumar Saini <saini123hitesh@gmail.com>.
+# All rights reserved.
+# Use of this source code is governed by MIT license that can be found in the LICENSE file.
+
+cmake_minimum_required(VERSION 3.14)
+
+set(PROJECT_NAME "media_kit_native_event_loop")
+project(${PROJECT_NAME} LANGUAGES CXX)
+
+add_subdirectory(
+  "${CMAKE_CURRENT_SOURCE_DIR}/../src"
+  "${CMAKE_CURRENT_BINARY_DIR}/shared"
+)
+
+set(
+  media_kit_native_event_loop_bundled_libraries
+  $<TARGET_FILE:media_kit_native_event_loop>
+  PARENT_SCOPE
+)

--- a/media_kit_test/lib/main.dart
+++ b/media_kit_test/lib/main.dart
@@ -932,7 +932,9 @@ class _StressTestScreenState extends State<StressTestScreen> {
     Future.microtask(
       () async {
         for (int i = 0; i < count; i++) {
-          final player = Player();
+          final player = Player(
+            configuration: const PlayerConfiguration(events: false),
+          );
           final controller = await VideoController.create(player.handle);
           players.add(player);
           controllers.add(controller);

--- a/media_kit_test/lib/main.dart
+++ b/media_kit_test/lib/main.dart
@@ -922,7 +922,7 @@ class StressTestScreen extends StatefulWidget {
 }
 
 class _StressTestScreenState extends State<StressTestScreen> {
-  static const int count = 4;
+  static const int count = 20;
   List<Player> players = [];
   List<VideoController> controllers = [];
 

--- a/media_kit_test/pubspec.yaml
+++ b/media_kit_test/pubspec.yaml
@@ -16,6 +16,8 @@ dependencies:
     path: ../media_kit
   media_kit_video:
     path: ../media_kit_video
+  media_kit_native_event_loop:
+    path: ../media_kit_native_event_loop
   media_kit_libs_windows_video:
     path: ../media_kit_libs_windows_video
   media_kit_libs_linux:


### PR DESCRIPTION
I don't have much time to document how it'd work, implementation should be self-explanatory.

A drop-in solution to resolve the issue. Simply adding the package to `pubspec.yaml` will allow customers to use more than 8 instances of `Player` simultaneously without any issues. [`package:media_kit`](https://github.com/alexmercerind/media_kit/tree/main/media_kit) will switch to this implementation automatically if the shared library generated by this target is found. Otherwise, it will fallback to default [`Isolate` based event handling](https://github.com/alexmercerind/media_kit/blob/main/media_kit/lib/src/libmpv/core/initializer.dart).

```yaml
dependencies:
  media_kit_native_event_loop: ^1.0.0
```

Closes #40.
