### PR TITLE
fix: improve libmpv discovery

### DIFF
--- a/media_kit/lib/src/libmpv/core/initializer.dart
+++ b/media_kit/lib/src/libmpv/core/initializer.dart
@@ -12,14 +12,12 @@ import 'initializer_native_event_loop.dart' as initializer_native_event_loop;
 /// See package:media_kit_native_event_loop for more details.
 ///
 Future<Pointer<mpv_handle>> create(
-  String path,
+  String? path,
   Future<void> Function(Pointer<mpv_event> event)? callback,
 ) async {
   try {
     return await initializer_native_event_loop.create(path, callback);
-  } catch (exception, stacktrace) {
-    print(exception);
-    print(stacktrace);
+  } catch (exception) {
     return await initializer_isolate.create(path, callback);
   }
 }

--- a/media_kit/lib/src/libmpv/core/initializer_native_event_loop.dart
+++ b/media_kit/lib/src/libmpv/core/initializer_native_event_loop.dart
@@ -13,6 +13,7 @@ import 'dart:isolate';
 import 'dart:collection';
 
 import 'package:media_kit/generated/libmpv/bindings.dart';
+import 'package:media_kit/src/libmpv/core/native_library.dart';
 
 /// Name of the shared library used for platform specific threaded event handling.
 ///
@@ -74,10 +75,8 @@ final receiver = ReceivePort()
   );
 
 /// Creates & returns initialized [Pointer] to [mpv_handle] whose event loop is running on native thread.
-///
-/// Pass [path] to libmpv dynamic library & [callback] to receive event callbacks as [Pointer] to [mpv_event].
 Future<Pointer<mpv_handle>> create(
-  String path,
+  String? path,
   Future<void> Function(Pointer<mpv_event> event)? callback,
 ) async {
   // Load native functions from the shared library on first call.
@@ -115,13 +114,13 @@ Future<Pointer<mpv_handle>> create(
   // Primarily, this will happen when the shared library is not found i.e. package:media_kit_native_event_loop is not installed.
   if (MediaKitEventLoopHandlerRegister == null ||
       MediaKitEventLoopHandlerNotify == null) {
-    throw Exception(
-      'package:media_kit/src/core/initializer_event_loop.dart: Unable to find native event loop shared library.',
-    );
+    throw Exception('Unable to find native event loop shared library.');
   }
 
   // Create [mpv_handle] & initialize it.
-  final mpv = MPV(DynamicLibrary.open(path));
+  final mpv = MPV(
+    path == null ? NativeLibrary.find() : DynamicLibrary.open(path),
+  );
   final handle = mpv.mpv_create();
   mpv.mpv_initialize(handle);
 

--- a/media_kit/lib/src/libmpv/player.dart
+++ b/media_kit/lib/src/libmpv/player.dart
@@ -999,10 +999,9 @@ class Player extends PlatformPlayer {
   }
 
   Future<void> _create() async {
-    final libmpv = await NativeLibrary.find(path: configuration.libmpv);
-    _libmpv = generated.MPV(DynamicLibrary.open(libmpv));
+    _libmpv = generated.MPV(NativeLibrary.find(path: configuration.libmpv));
     final result = await create(
-      libmpv,
+      configuration.libmpv,
       configuration.events ? _handler : null,
     );
     <String, int>{


### PR DESCRIPTION
No need to manually at various places. [`package:media_kit_native_event_loop`](https://github.com/alexmercerind/media_kit/tree/main/media_kit_native_event_loop) follows the same.

Host system automatically handles it e.g. 
- Windows looking at `%PATH%` & executable directory etc.
- GNU/Linux using `LD_LIBRARY_PATH`.

Closes #47.
