### PR TITLE
add mpv logs support

### DIFF
--- a/media_kit/lib/src/models/player_log.dart
+++ b/media_kit/lib/src/models/player_log.dart
@@ -1,0 +1,23 @@
+/// This file is a part of media_kit (https://github.com/alexmercerind/media_kit).
+///
+/// Copyright © 2021 & onwards, Hitesh Kumar Saini <saini123hitesh@gmail.com>.
+/// All rights reserved.
+/// Use of this source code is governed by MIT license that can be found in the LICENSE file.
+
+/// A log message sent by the libmpv backend.
+class PlayerLog {
+  /// The sender of the message.
+  final String prefix;
+
+  /// The log level.
+  final String level;
+
+  /// The log message.
+  final String text;
+
+  PlayerLog({
+    required this.prefix,
+    required this.level,
+    required this.text,
+  });
+}

--- a/media_kit/lib/src/models/player_streams.dart
+++ b/media_kit/lib/src/models/player_streams.dart
@@ -7,6 +7,7 @@
 import 'package:media_kit/src/models/playlist.dart';
 import 'package:media_kit/src/models/audio_params.dart';
 import 'package:media_kit/src/models/player_error.dart';
+import 'package:media_kit/src/models/player_log.dart';
 
 /// Private class for event handling of [Player].
 class PlayerStreams {
@@ -44,6 +45,9 @@ class PlayerStreams {
   /// Audio bitrate of the currently playing [Media] in the [Player].
   final Stream<double?> audioBitrate;
 
+  /// [Stream] emitting [PlayerLog]s.
+  final Stream<PlayerLog> log;
+
   /// [Stream] raising [PlayerError]s.
   /// This may be used to catch errors raised by [Player].
   final Stream<PlayerError> error;
@@ -58,6 +62,7 @@ class PlayerStreams {
     this.rate,
     this.pitch,
     this.isBuffering,
+    this.log,
     this.error,
     this.audioParams,
     this.audioBitrate,

--- a/media_kit/lib/src/platform_player.dart
+++ b/media_kit/lib/src/platform_player.dart
@@ -11,9 +11,43 @@ import 'package:media_kit/src/models/media.dart';
 import 'package:media_kit/src/models/playlist.dart';
 import 'package:media_kit/src/models/audio_params.dart';
 import 'package:media_kit/src/models/player_error.dart';
+import 'package:media_kit/src/models/player_log.dart';
 import 'package:media_kit/src/models/player_state.dart';
 import 'package:media_kit/src/models/playlist_mode.dart';
 import 'package:media_kit/src/models/player_streams.dart';
+
+/// {@template mpv_log_level}
+///
+/// MPVLogLevel
+/// --------------------
+/// Options to customise the [Player] libmpv backend log level.
+///
+/// {@endtemplate}
+enum MPVLogLevel {
+  /// Disable absolutely all messages.
+  none,
+
+  /// Critical/aborting errors.
+  fatal,
+
+  /// Simple errors.
+  error,
+
+  /// Possible problems.
+  warn,
+
+  /// Informational message.
+  info,
+
+  /// Noisy informational message.
+  v,
+
+  /// Very noisy technical information.
+  debug,
+
+  /// Extremely noisy.
+  trace,
+}
 
 /// {@template player_configuration}
 ///
@@ -26,6 +60,10 @@ class PlayerConfiguration {
   /// Enables or disables event handling. This may improve performance if there is no need to listen to events.
   /// Default: `true`.
   final bool events;
+
+  /// Sets the log level on libmpv backend.
+  /// Default: `none`.
+  final MPVLogLevel logLevel;
 
   /// Enables on-screen controls on libmpv backend.
   /// Default: `false`.
@@ -67,6 +105,7 @@ class PlayerConfiguration {
   /// {@macro player_configuration}
   const PlayerConfiguration({
     this.events = true,
+    this.logLevel = MPVLogLevel.none,
     this.osc = false,
     this.vid,
     this.vo,
@@ -108,6 +147,7 @@ abstract class PlatformPlayer {
     rateController.stream,
     pitchController.stream,
     isBufferingController.stream,
+    logController.stream,
     errorController.stream,
     audioParamsController.stream,
     audioBitrateController.stream,
@@ -124,6 +164,7 @@ abstract class PlatformPlayer {
     await rateController.close();
     await pitchController.close();
     await isBufferingController.close();
+    await logController.close();
     await errorController.close();
     await audioParamsController.close();
     await audioBitrateController.close();
@@ -267,6 +308,10 @@ abstract class PlatformPlayer {
 
   @protected
   final StreamController<bool> isBufferingController =
+      StreamController.broadcast();
+
+  @protected
+  final StreamController<PlayerLog> logController =
       StreamController.broadcast();
 
   @protected

--- a/media_kit_test/lib/main.dart
+++ b/media_kit_test/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'dart:async';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
 
@@ -165,13 +166,18 @@ class SimpleScreen extends StatefulWidget {
 
 class _SimpleScreenState extends State<SimpleScreen> {
   // Create a [Player] instance from `package:media_kit`.
-  final Player player = Player();
+  final Player player = Player(
+    configuration: const PlayerConfiguration(
+      logLevel: MPVLogLevel.warn,
+    ),
+  );
   // Reference to the [VideoController] instance.
   VideoController? controller;
 
   @override
   void initState() {
     super.initState();
+    pipeLogsToConsole(player);
     Future.microtask(() async {
       // Create a [VideoController] instance from `package:media_kit_video`.
       // Pass the [handle] of the [Player] from `package:media_kit` to the [VideoController] constructor.
@@ -316,7 +322,11 @@ class SimpleStream extends StatefulWidget {
 
 class _SimpleStreamState extends State<SimpleStream> {
   // Create a [Player] instance from `package:media_kit`.
-  final Player player = Player();
+  final Player player = Player(
+    configuration: const PlayerConfiguration(
+      logLevel: MPVLogLevel.warn,
+    ),
+  );
   // Reference to the [VideoController] instance.
   VideoController? controller;
   final _formKey = GlobalKey<FormState>();
@@ -326,6 +336,7 @@ class _SimpleStreamState extends State<SimpleStream> {
   @override
   void initState() {
     super.initState();
+    pipeLogsToConsole(player);
     Future.microtask(() async {
       // Create a [VideoController] instance from `package:media_kit_video`.
       // Pass the [handle] of the [Player] from `package:media_kit` to the [VideoController] constructor.
@@ -1108,3 +1119,11 @@ String? _fontFamily = {
   'android': 'Roboto',
   'ios': 'SF Pro Text',
 }[Platform.operatingSystem];
+
+void pipeLogsToConsole(Player player) {
+  player.streams.log.listen((event) {
+    if (kDebugMode) {
+      print("mpv: ${event.prefix}: ${event.level}: ${event.text}");
+    }
+  });
+}


### PR DESCRIPTION
As the title suggests, this adds support for mpv logs:

1. `media_kit`: Added a `log` stream to retrieve logs from mpv
2. `media_kit`: Added a new option in the `PlayerConfiguration` to choose the level of logs you want to get. Defaults to `none`.
3. `media_kit_test`: Changed the player configuration of `SimpleScreen` & `SimpleStream`, to pipe the logs of min level `warn` to the console in debug mode

---

@alexmercerind Feel free to modify the doc or code if you want 🙂