### PR TITLE
add CI build for macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: "true"
-      - run: brew install p7zip
       - uses: subosito/flutter-action@v1
         with:
           channel: "stable"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           name: media_kit_test_win32_x64
           path: media_kit_test/media_kit_test_win32_x64.7z
       - uses: softprops/action-gh-release@v1
+        if: github.ref == 'refs/heads/main'
         with:
           draft: true
           prerelease: false
@@ -51,9 +52,37 @@ jobs:
           name: media_kit_test_linux_x64
           path: media_kit_test/media_kit_test_linux_x64.7z
       - uses: softprops/action-gh-release@v1
+        if: github.ref == 'refs/heads/main'
         with:
           draft: true
           prerelease: false
           tag_name: "vnext"
           files: |
             media_kit_test/media_kit_test_linux_x64.7z
+
+  macos:
+    name: macOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: "true"
+      - run: brew install p7zip
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: "stable"
+      - run: flutter pub get
+      - run: flutter build macos --verbose
+      - run: 7z a media_kit_test_macos_universal.7z build/macos/Build/Products/Release/media_kit_test.app
+      - uses: actions/upload-artifact@v1
+        with:
+          name: media_kit_test_macos_universal
+          path: media_kit_test/media_kit_test_macos_universal.7z
+      - uses: softprops/action-gh-release@v1
+        if: github.ref == 'refs/heads/main'
+        with:
+          draft: true
+          prerelease: false
+          tag_name: "vnext"
+          files: |
+            media_kit_test/media_kit_test_macos_universal.7z


### PR DESCRIPTION
Add CI universal build for macOS (amd64 & arm64).
I tested the artifact, it works.

I also added a condition on the release creation so that it only happens on the main branch: [.github/workflows/ci.yml#L82](https://github.com/birros/media_kit/blob/3a0817296155635dab491d4594fac9c89aa0df35/.github/workflows/ci.yml#L82)

@alexmercerind If it's ok with you, we can merge.