### PR TITLE
docs: update macOS & iOS doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,9 @@ dependencies:
   media_kit_libs_ios_video: ^1.0.0         # iOS package for video (& audio) native libraries.
 ```
 
-The minimum supported iOS version is 13.0 ([#libmpv-build](https://github.com/birros/libmpv-build/blob/v0.1.1/cross-files/ios-arm64.ini#L18)).
+The minimum supported iOS version is 13.0 ([#libmpv-darwin-build](https://github.com/media-kit/libmpv-darwin-build/blob/v0.3.1/cross-files/ios-arm64.ini#L18)).
+
+Also, software rendering is forced in the iOS simulator, due to an incompatibility with OpenGL ES.
 
 ## Goals
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,27 @@ dependencies:
   media_kit_libs_macos_video: ^1.0.0       # macOS package for video (& audio) native libraries.
 ```
 
+The minimum supported macOS version is 10.14 ([#libmpv-build](https://github.com/birros/libmpv-build/blob/v0.1.1/cross-files/darwin-arm64.ini#L18)).
+
+Also, during the build phase, the following warnings are not critical and cannot be silenced:
+
+```log
+#import "Headers/media_kit_video-Swift.h"
+        ^
+/path/to/media_kit/media_kit_test/build/macos/Build/Products/Debug/media_kit_video/media_kit_video.framework/Headers/media_kit_video-Swift.h:270:31: warning: 'objc_ownership' only applies to Objective-C object or block pointer types; type here is 'CVPixelBufferRef' (aka 'struct __CVBuffer *')
+- (CVPixelBufferRef _Nullable __unsafe_unretained)copyPixelBuffer SWIFT_WARN_UNUSED_RESULT;
+```
+
+```log
+# 1 "<command line>" 1
+ ^
+<command line>:20:9: warning: 'POD_CONFIGURATION_DEBUG' macro redefined
+#define POD_CONFIGURATION_DEBUG 1 DEBUG=1 
+        ^
+#define POD_CONFIGURATION_DEBUG 1
+        ^
+```
+
 ### iOS
 
 Everything ready. Just add one of the following packages to your `pubspec.yaml`.
@@ -284,6 +305,8 @@ dependencies:
   ...
   media_kit_libs_ios_video: ^1.0.0         # iOS package for video (& audio) native libraries.
 ```
+
+The minimum supported iOS version is 13.0 ([#libmpv-build](https://github.com/birros/libmpv-build/blob/v0.1.1/cross-files/ios-arm64.ini#L18)).
 
 ## Goals
 
@@ -712,11 +735,20 @@ On Flutter Linux, [both OpenGL (H/W) & pixel buffer (S/W) APIs](https://github.c
 
 #### macOS
 
-_TODO: documentation_
+On macOS the current implementation is based on `libmpv` and can be summarized as follows:
+1. H/W video decoding: mpv option `hwdec` is set to `auto`, does not depend on a pixelBuffer
+2. OpenGL rendering to an OpenGL texture backed by a pixelBuffer interoperable with Metal ([#CVPixelBuffer](https://developer.apple.com/documentation/corevideo/cvpixelbuffer-q2e))
+3. This pixelBuffer is then read by Flutter to display the frame
+
+Possible improvements :
+- render directly to a Metal texture:
+  - use ANGLE to not depend on the host OpenGL implementation, deprecated by Apple
+  - use a future Metal API natively developed by mpv
+- share the Metal texture between `media_kit_video` and Flutter, without using a pixelBuffer
 
 #### iOS
 
-_TODO: documentation_
+On iOS, the implementation shares much of its code and logic with macOS, the main difference is the use of OpenGL ES instead of OpenGL.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ dependencies:
   media_kit_libs_macos_video: ^1.0.0       # macOS package for video (& audio) native libraries.
 ```
 
-The minimum supported macOS version is 10.14 ([#libmpv-build](https://github.com/birros/libmpv-build/blob/v0.1.1/cross-files/darwin-arm64.ini#L18)).
+The minimum supported macOS version is 11.0 ([#libmpv-darwin-build](https://github.com/media-kit/libmpv-darwin-build/blob/v0.3.1/cross-files/macos-arm64.ini#L18)).
 
 Also, during the build phase, the following warnings are not critical and cannot be silenced:
 

--- a/media_kit/README.md
+++ b/media_kit/README.md
@@ -298,6 +298,8 @@ dependencies:
 
 The minimum supported iOS version is 13.0 ([#libmpv-darwin-build](https://github.com/media-kit/libmpv-darwin-build/blob/v0.3.1/cross-files/ios-arm64.ini#L18)).
 
+Also, software rendering is forced in the iOS simulator, due to an incompatibility with OpenGL ES.
+
 ## Goals
 
 The primary goal of [package:media_kit](https://github.com/alexmercerind/media_kit) is to become a **strong, performant, stable, feature-proof & modular** media playback library for Flutter. The idea is to support both **audio & video playback**.

--- a/media_kit/README.md
+++ b/media_kit/README.md
@@ -265,7 +265,7 @@ dependencies:
   media_kit_libs_macos_video: ^1.0.0       # macOS package for video (& audio) native libraries.
 ```
 
-The minimum supported macOS version is 10.14 ([#libmpv-build](https://github.com/birros/libmpv-build/blob/v0.1.1/cross-files/darwin-arm64.ini#L18)).
+The minimum supported macOS version is 11.0 ([#libmpv-darwin-build](https://github.com/media-kit/libmpv-darwin-build/blob/v0.3.1/cross-files/macos-arm64.ini#L18)).
 
 Also, during the build phase, the following warnings are not critical and cannot be silenced:
 
@@ -296,7 +296,7 @@ dependencies:
   media_kit_libs_ios_video: ^1.0.0         # iOS package for video (& audio) native libraries.
 ```
 
-The minimum supported iOS version is 13.0 ([#libmpv-build](https://github.com/birros/libmpv-build/blob/v0.1.1/cross-files/ios-arm64.ini#L18)).
+The minimum supported iOS version is 13.0 ([#libmpv-darwin-build](https://github.com/media-kit/libmpv-darwin-build/blob/v0.3.1/cross-files/ios-arm64.ini#L18)).
 
 ## Goals
 

--- a/media_kit/README.md
+++ b/media_kit/README.md
@@ -265,6 +265,27 @@ dependencies:
   media_kit_libs_macos_video: ^1.0.0       # macOS package for video (& audio) native libraries.
 ```
 
+The minimum supported macOS version is 10.14 ([#libmpv-build](https://github.com/birros/libmpv-build/blob/v0.1.1/cross-files/darwin-arm64.ini#L18)).
+
+Also, during the build phase, the following warnings are not critical and cannot be silenced:
+
+```log
+#import "Headers/media_kit_video-Swift.h"
+        ^
+/path/to/media_kit/media_kit_test/build/macos/Build/Products/Debug/media_kit_video/media_kit_video.framework/Headers/media_kit_video-Swift.h:270:31: warning: 'objc_ownership' only applies to Objective-C object or block pointer types; type here is 'CVPixelBufferRef' (aka 'struct __CVBuffer *')
+- (CVPixelBufferRef _Nullable __unsafe_unretained)copyPixelBuffer SWIFT_WARN_UNUSED_RESULT;
+```
+
+```log
+# 1 "<command line>" 1
+ ^
+<command line>:20:9: warning: 'POD_CONFIGURATION_DEBUG' macro redefined
+#define POD_CONFIGURATION_DEBUG 1 DEBUG=1 
+        ^
+#define POD_CONFIGURATION_DEBUG 1
+        ^
+```
+
 ### iOS
 
 Everything ready. Just add one of the following packages to your `pubspec.yaml`.
@@ -274,6 +295,8 @@ dependencies:
   ...
   media_kit_libs_ios_video: ^1.0.0         # iOS package for video (& audio) native libraries.
 ```
+
+The minimum supported iOS version is 13.0 ([#libmpv-build](https://github.com/birros/libmpv-build/blob/v0.1.1/cross-files/ios-arm64.ini#L18)).
 
 ## Goals
 


### PR DESCRIPTION
I just added the doc for the setup and the implementation for macOS & iOS.

@alexmercerind I let you add the graphs (if you want).
For info iOS & macOS share a lot of code, maybe more in the future, I voluntarily duplicated some parts of the `TextureHW` code because they are likely to change a lot in the future. For the moment their logic is almost identical.

## TODO

- [x] Update min macOS version to 11.0