### PR TITLE
fix: pub for macOS & iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ Add in your `pubspec.yaml`:
 dependencies:
   media_kit: ^0.0.3
   # For video rendering.
-  media_kit_video: ^0.0.3
+  media_kit_video: ^0.0.4
   # Enables support for higher number of concurrent instances. Optional.
   media_kit_native_event_loop: ^1.0.2
   # Pick based on your requirements / platform:
   media_kit_libs_windows_video: ^1.0.1          # Windows package for video (& audio) native libraries.
-  media_kit_libs_ios_video: ^1.0.1              # iOS package for video (& audio) native libraries.
-  media_kit_libs_macos_video: ^1.0.1            # macOS package for video (& audio) native libraries.
+  media_kit_libs_ios_video: ^1.0.2              # iOS package for video (& audio) native libraries.
+  media_kit_libs_macos_video: ^1.0.2            # macOS package for video (& audio) native libraries.
   media_kit_libs_linux: ^1.0.1                  # Linux dependency package.
 ```
 
@@ -284,7 +284,7 @@ Everything ready. Just add one of the following packages to your `pubspec.yaml`.
 ```yaml
 dependencies:
   ...
-  media_kit_libs_macos_video: ^1.0.0       # macOS package for video (& audio) native libraries.
+  media_kit_libs_macos_video: ^1.0.2       # macOS package for video (& audio) native libraries.
 ```
 
 The minimum supported macOS version is 11.0 ([#libmpv-darwin-build](https://github.com/media-kit/libmpv-darwin-build/blob/v0.3.1/cross-files/macos-arm64.ini#L18)).
@@ -315,7 +315,7 @@ Everything ready. Just add one of the following packages to your `pubspec.yaml`.
 ```yaml
 dependencies:
   ...
-  media_kit_libs_ios_video: ^1.0.0         # iOS package for video (& audio) native libraries.
+  media_kit_libs_ios_video: ^1.0.2         # iOS package for video (& audio) native libraries.
 ```
 
 The minimum supported iOS version is 13.0 ([#libmpv-darwin-build](https://github.com/media-kit/libmpv-darwin-build/blob/v0.3.1/cross-files/ios-arm64.ini#L18)).

--- a/media_kit/CHANGELOG.md
+++ b/media_kit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.3+3
+
+- docs: document updated `media_kit_video`, `media_kit_libs_macos_video` and `media_kit_libs_ios_video` 
+
 ## 0.0.3+2
 
 - docs: document updated `media_kit_video`

--- a/media_kit/README.md
+++ b/media_kit/README.md
@@ -41,13 +41,13 @@ Add in your `pubspec.yaml`:
 dependencies:
   media_kit: ^0.0.3
   # For video rendering.
-  media_kit_video: ^0.0.3
+  media_kit_video: ^0.0.4
   # Enables support for higher number of concurrent instances. Optional.
   media_kit_native_event_loop: ^1.0.2
   # Pick based on your requirements / platform:
   media_kit_libs_windows_video: ^1.0.1          # Windows package for video (& audio) native libraries.
-  media_kit_libs_ios_video: ^1.0.1              # iOS package for video (& audio) native libraries.
-  media_kit_libs_macos_video: ^1.0.1            # macOS package for video (& audio) native libraries.
+  media_kit_libs_ios_video: ^1.0.2              # iOS package for video (& audio) native libraries.
+  media_kit_libs_macos_video: ^1.0.2            # macOS package for video (& audio) native libraries.
   media_kit_libs_linux: ^1.0.1                  # Linux dependency package.
 ```
 
@@ -267,7 +267,7 @@ Everything ready. Just add one of the following packages to your `pubspec.yaml`.
 ```yaml
 dependencies:
   ...
-  media_kit_libs_macos_video: ^1.0.0       # macOS package for video (& audio) native libraries.
+  media_kit_libs_macos_video: ^1.0.2       # macOS package for video (& audio) native libraries.
 ```
 
 The minimum supported macOS version is 11.0 ([#libmpv-darwin-build](https://github.com/media-kit/libmpv-darwin-build/blob/v0.3.1/cross-files/macos-arm64.ini#L18)).
@@ -298,7 +298,7 @@ Everything ready. Just add one of the following packages to your `pubspec.yaml`.
 ```yaml
 dependencies:
   ...
-  media_kit_libs_ios_video: ^1.0.0         # iOS package for video (& audio) native libraries.
+  media_kit_libs_ios_video: ^1.0.2         # iOS package for video (& audio) native libraries.
 ```
 
 The minimum supported iOS version is 13.0 ([#libmpv-darwin-build](https://github.com/media-kit/libmpv-darwin-build/blob/v0.3.1/cross-files/ios-arm64.ini#L18)).

--- a/media_kit/pubspec.yaml
+++ b/media_kit/pubspec.yaml
@@ -2,7 +2,7 @@ name: media_kit
 description: A complete video & audio playback library for Flutter & Dart. Performant, stable, feature-proof & modular.
 homepage: https://github.com/alexmercerind/media_kit
 repository: https://github.com/alexmercerind/media_kit
-version: 0.0.3+2
+version: 0.0.3+3
 funding:
   - https://www.github.com/sponsors/alexmercerind
 

--- a/media_kit_libs_ios_video/CHANGELOG.md
+++ b/media_kit_libs_ios_video/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- fix: use `mkdir` instead of `.gitkeep`
+
 ## 1.0.1
 
 - fix: unable to publish iOS to AppStore

--- a/media_kit_libs_ios_video/ios/.gitignore
+++ b/media_kit_libs_ios_video/ios/.gitignore
@@ -1,1 +1,3 @@
 .cache
+Frameworks
+Headers

--- a/media_kit_libs_ios_video/ios/Frameworks/.gitignore
+++ b/media_kit_libs_ios_video/ios/Frameworks/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/media_kit_libs_ios_video/ios/Headers/mpv/.gitignore
+++ b/media_kit_libs_ios_video/ios/Headers/mpv/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/media_kit_libs_ios_video/ios/Makefile
+++ b/media_kit_libs_ios_video/ios/Makefile
@@ -21,6 +21,7 @@ MPV_HEADERS_SHA256SUM=41df981b7b84e33a2ef4478aaf81d6f4f5c8b9cd2c0d337ac142fc20b3
 	ln -s mpv-${MPV_HEADERS_VERSION}.tar.gz .cache/headers/mpv.tar.gz
 
 Headers/mpv/*.h: .cache/headers/mpv.tar.gz
+	mkdir -p Headers/mpv
 	tar -xvf .cache/headers/mpv.tar.gz --strip-components 2 -C Headers/mpv/ 'mpv-*/libmpv/*.h'
 	touch Headers/mpv/*.h
 
@@ -39,6 +40,7 @@ Headers/mpv/*.h: .cache/headers/mpv.tar.gz
 	ln -s libmpv-xcframeworks-${MPV_XCFRAMEWORKS_VERSION}-ios-universal.tar.gz .cache/xcframeworks/libmpv-xcframeworks-ios-universal.tar.gz
 
 Frameworks/*.xcframework: .cache/xcframeworks/libmpv-xcframeworks-ios-universal.tar.gz
+	mkdir -p Frameworks
 	rm -rf Frameworks/*.xcframework
 	tar -xvf .cache/xcframeworks/libmpv-xcframeworks-ios-universal.tar.gz --strip-components 1 -C Frameworks
 	touch Frameworks/*.xcframework

--- a/media_kit_libs_ios_video/pubspec.yaml
+++ b/media_kit_libs_ios_video/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_libs_ios_video
 description: iOS package providing video (& audio) native libraries for package:media_kit.
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/alexmercerind/media_kit.git
 repository: https://github.com/alexmercerind/media_kit.git
 funding:

--- a/media_kit_libs_macos_video/CHANGELOG.md
+++ b/media_kit_libs_macos_video/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- fix: use `mkdir` instead of `.gitkeep`
+
 ## 1.0.1
 
 - fix: add `.framework` & `.xcframework` for all libs

--- a/media_kit_libs_macos_video/macos/.gitignore
+++ b/media_kit_libs_macos_video/macos/.gitignore
@@ -1,1 +1,3 @@
 .cache
+Frameworks
+Headers

--- a/media_kit_libs_macos_video/macos/Frameworks/.gitignore
+++ b/media_kit_libs_macos_video/macos/Frameworks/.gitignore
@@ -1,1 +1,0 @@
-*.xcframework

--- a/media_kit_libs_macos_video/macos/Headers/mpv/.gitignore
+++ b/media_kit_libs_macos_video/macos/Headers/mpv/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/media_kit_libs_macos_video/macos/Makefile
+++ b/media_kit_libs_macos_video/macos/Makefile
@@ -21,6 +21,7 @@ MPV_HEADERS_SHA256SUM=41df981b7b84e33a2ef4478aaf81d6f4f5c8b9cd2c0d337ac142fc20b3
 	ln -s mpv-${MPV_HEADERS_VERSION}.tar.gz .cache/headers/mpv.tar.gz
 
 Headers/mpv/*.h: .cache/headers/mpv.tar.gz
+	mkdir -p Headers/mpv
 	tar -xvf .cache/headers/mpv.tar.gz --strip-components 2 -C Headers/mpv/ 'mpv-*/libmpv/*.h'
 	touch Headers/mpv/*.h
 
@@ -39,6 +40,7 @@ Headers/mpv/*.h: .cache/headers/mpv.tar.gz
 	ln -s libmpv-xcframeworks-${MPV_XCFRAMEWORKS_VERSION}-macos-universal.tar.gz .cache/xcframeworks/libmpv-xcframeworks-macos-universal.tar.gz
 
 Frameworks/*.xcframework: .cache/xcframeworks/libmpv-xcframeworks-macos-universal.tar.gz
+	mkdir -p Frameworks
 	rm -rf Frameworks/*.xcframework
 	tar -xvf .cache/xcframeworks/libmpv-xcframeworks-macos-universal.tar.gz --strip-components 1 -C Frameworks
 	touch Frameworks/*.xcframework

--- a/media_kit_libs_macos_video/pubspec.yaml
+++ b/media_kit_libs_macos_video/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_libs_macos_video
 description: macOS package providing video (& audio) native libraries for package:media_kit.
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/alexmercerind/media_kit.git
 repository: https://github.com/alexmercerind/media_kit.git
 funding:

--- a/media_kit_video/CHANGELOG.md
+++ b/media_kit_video/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4
+
+- fix: use `mkdir` instead of `.gitkeep`
+
 ## 0.0.3
 
 - fix: add `.framework` & `.xcframework` for all libs

--- a/media_kit_video/ios/.gitignore
+++ b/media_kit_video/ios/.gitignore
@@ -1,1 +1,2 @@
 .cache
+Headers

--- a/media_kit_video/ios/Headers/mpv/.gitignore
+++ b/media_kit_video/ios/Headers/mpv/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/media_kit_video/ios/Makefile
+++ b/media_kit_video/ios/Makefile
@@ -13,12 +13,12 @@ MPV_HEADERS_SHA256SUM=41df981b7b84e33a2ef4478aaf81d6f4f5c8b9cd2c0d337ac142fc20b3
 	mv .cache/headers/mpv.tar.gz.tmp .cache/headers/mpv-${MPV_HEADERS_VERSION}.tar.gz
 	touch .cache/headers/mpv-${MPV_HEADERS_VERSION}.tar.gz
 
-
 .cache/headers/mpv.tar.gz: .cache/headers/mpv-${MPV_HEADERS_VERSION}.tar.gz
 	rm -f .cache/headers/mpv.tar.gz
 	ln -s mpv-${MPV_HEADERS_VERSION}.tar.gz .cache/headers/mpv.tar.gz
 
 Headers/mpv/*.h: .cache/headers/mpv.tar.gz
+	mkdir -p Headers/mpv
 	tar -xvf .cache/headers/mpv.tar.gz --strip-components 2 -C Headers/mpv/ 'mpv-*/libmpv/*.h'
 	touch Headers/mpv/*.h
 

--- a/media_kit_video/macos/.gitignore
+++ b/media_kit_video/macos/.gitignore
@@ -1,1 +1,2 @@
 .cache
+Headers

--- a/media_kit_video/macos/Headers/mpv/.gitignore
+++ b/media_kit_video/macos/Headers/mpv/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/media_kit_video/macos/Makefile
+++ b/media_kit_video/macos/Makefile
@@ -13,12 +13,12 @@ MPV_HEADERS_SHA256SUM=41df981b7b84e33a2ef4478aaf81d6f4f5c8b9cd2c0d337ac142fc20b3
 	mv .cache/headers/mpv.tar.gz.tmp .cache/headers/mpv-${MPV_HEADERS_VERSION}.tar.gz
 	touch .cache/headers/mpv-${MPV_HEADERS_VERSION}.tar.gz
 
-
 .cache/headers/mpv.tar.gz: .cache/headers/mpv-${MPV_HEADERS_VERSION}.tar.gz
 	rm -f .cache/headers/mpv.tar.gz
 	ln -s mpv-${MPV_HEADERS_VERSION}.tar.gz .cache/headers/mpv.tar.gz
 
 Headers/mpv/*.h: .cache/headers/mpv.tar.gz
+	mkdir -p Headers/mpv
 	tar -xvf .cache/headers/mpv.tar.gz --strip-components 2 -C Headers/mpv/ 'mpv-*/libmpv/*.h'
 	touch Headers/mpv/*.h
 

--- a/media_kit_video/pubspec.yaml
+++ b/media_kit_video/pubspec.yaml
@@ -2,7 +2,7 @@ name: media_kit_video
 description: Native implementation for video playback in package:media_kit.
 homepage: https://github.com/alexmercerind/media_kit
 repository: https://github.com/alexmercerind/media_kit
-version: 0.0.3
+version: 0.0.4
 funding:
   - https://www.github.com/sponsors/alexmercerind
 


### PR DESCRIPTION
Fix #103 & #104

pub don't keep dot files when publishing a package.
So I use mkdir to create required empty folders.