### PR TITLE
feat: buffer stream & state

### DIFF
--- a/media_kit/lib/src/libmpv/player.dart
+++ b/media_kit/lib/src/libmpv/player.dart
@@ -775,17 +775,6 @@ class Player extends PlatformPlayer {
     if (event.ref.event_id ==
         generated.mpv_event_id.MPV_EVENT_PROPERTY_CHANGE) {
       final prop = event.ref.data.cast<generated.mpv_event_property>();
-
-      if (prop.ref.name.cast<Utf8>().toDartString() == 'demuxer-cache-time' &&
-          prop.ref.format == generated.mpv_format.MPV_FORMAT_DOUBLE) {
-        final lastBuffered = Duration(
-            microseconds: prop.ref.data.cast<Double>().value * 1e6 ~/ 1);
-        state = state.copyWith(lastBuffered: lastBuffered);
-        if (!lastBufferedController.isClosed) {
-          lastBufferedController.add(lastBuffered);
-        }
-      }
-
       if (prop.ref.name.cast<Utf8>().toDartString() == 'pause' &&
           prop.ref.format == generated.mpv_format.MPV_FORMAT_FLAG) {
         if (_allowPlayingStateChange) {
@@ -802,6 +791,16 @@ class Player extends PlatformPlayer {
         state = state.copyWith(buffering: buffering);
         if (!bufferingController.isClosed) {
           bufferingController.add(buffering);
+        }
+      }
+      if (prop.ref.name.cast<Utf8>().toDartString() == 'demuxer-cache-time' &&
+          prop.ref.format == generated.mpv_format.MPV_FORMAT_DOUBLE) {
+        final buffer = Duration(
+          microseconds: prop.ref.data.cast<Double>().value * 1e6 ~/ 1,
+        );
+        state = state.copyWith(buffer: buffer);
+        if (!bufferController.isClosed) {
+          bufferController.add(buffer);
         }
       }
       if (prop.ref.name.cast<Utf8>().toDartString() == 'time-pos' &&

--- a/media_kit/lib/src/models/player_state.dart
+++ b/media_kit/lib/src/models/player_state.dart
@@ -45,8 +45,9 @@ class PlayerState {
   /// Whether the [Player] is buffering.
   final bool buffering;
 
-  /// last buffered Duration of the currently playing [Media] in the [Player].
-  final Duration lastBuffered;
+  /// The total buffered duration of the currently playing [Media] in the [Player].
+  /// This indicates how much of the stream has been decoded & cached by the demuxer.
+  final Duration buffer;
 
   /// Audio parameters of the currently playing [Media].
   /// e.g. sample rate, channels, etc.
@@ -80,11 +81,11 @@ class PlayerState {
     this.completed = false,
     this.position = Duration.zero,
     this.duration = Duration.zero,
+    this.buffer = Duration.zero,
     this.volume = 1.0,
     this.rate = 1.0,
     this.pitch = 1.0,
     this.buffering = false,
-    this.lastBuffered = Duration.zero,
     this.audioParams = const AudioParams(),
     this.audioBitrate,
     this.audioDevice = const AudioDevice('auto', ''),
@@ -101,11 +102,11 @@ class PlayerState {
     bool? completed,
     Duration? position,
     Duration? duration,
+    Duration? buffer,
     double? volume,
     double? rate,
     double? pitch,
     bool? buffering,
-    Duration? lastBuffered,
     AudioParams? audioParams,
     double? audioBitrate,
     AudioDevice? audioDevice,
@@ -121,11 +122,11 @@ class PlayerState {
       completed: completed ?? this.completed,
       position: position ?? this.position,
       duration: duration ?? this.duration,
+      buffer: buffer ?? this.buffer,
       volume: volume ?? this.volume,
       rate: rate ?? this.rate,
       pitch: pitch ?? this.pitch,
       buffering: buffering ?? this.buffering,
-      lastBuffered: lastBuffered??this.lastBuffered,
       audioParams: audioParams ?? this.audioParams,
       audioBitrate: audioBitrate ?? this.audioBitrate,
       audioDevice: audioDevice ?? this.audioDevice,
@@ -144,11 +145,11 @@ class PlayerState {
       'completed: $completed, '
       'position: $position, '
       'duration: $duration, '
+      'buffer: $buffer, '
       'volume: $volume, '
       'rate: $rate, '
       'pitch: $pitch, '
       'buffering: $buffering, '
-      'lastBuffered: $lastBuffered, '
       'audioParams: $audioParams, '
       'audioBitrate: $audioBitrate, '
       'audioDevice: $audioDevice, '

--- a/media_kit/lib/src/models/player_state.dart
+++ b/media_kit/lib/src/models/player_state.dart
@@ -45,6 +45,9 @@ class PlayerState {
   /// Whether the [Player] is buffering.
   final bool buffering;
 
+  /// last buffered Duration of the currently playing [Media] in the [Player].
+  final Duration lastBuffered;
+
   /// Audio parameters of the currently playing [Media].
   /// e.g. sample rate, channels, etc.
   final AudioParams audioParams;
@@ -81,6 +84,7 @@ class PlayerState {
     this.rate = 1.0,
     this.pitch = 1.0,
     this.buffering = false,
+    this.lastBuffered = Duration.zero,
     this.audioParams = const AudioParams(),
     this.audioBitrate,
     this.audioDevice = const AudioDevice('auto', ''),
@@ -101,6 +105,7 @@ class PlayerState {
     double? rate,
     double? pitch,
     bool? buffering,
+    Duration? lastBuffered,
     AudioParams? audioParams,
     double? audioBitrate,
     AudioDevice? audioDevice,
@@ -120,6 +125,7 @@ class PlayerState {
       rate: rate ?? this.rate,
       pitch: pitch ?? this.pitch,
       buffering: buffering ?? this.buffering,
+      lastBuffered: lastBuffered??this.lastBuffered,
       audioParams: audioParams ?? this.audioParams,
       audioBitrate: audioBitrate ?? this.audioBitrate,
       audioDevice: audioDevice ?? this.audioDevice,
@@ -142,6 +148,7 @@ class PlayerState {
       'rate: $rate, '
       'pitch: $pitch, '
       'buffering: $buffering, '
+      'lastBuffered: $lastBuffered, '
       'audioParams: $audioParams, '
       'audioBitrate: $audioBitrate, '
       'audioDevice: $audioDevice, '

--- a/media_kit/lib/src/models/player_streams.dart
+++ b/media_kit/lib/src/models/player_streams.dart
@@ -35,6 +35,10 @@ class PlayerStreams {
   /// Duration of the currently playing [Media] in the [Player].
   final Stream<Duration> duration;
 
+  /// The total buffered duration of the currently playing [Media] in the [Player].
+  /// This indicates how much of the stream has been decoded & cached by the demuxer.
+  final Stream<Duration> buffer;
+
   /// Current volume of the [Player].
   final Stream<double> volume;
 
@@ -46,9 +50,6 @@ class PlayerStreams {
 
   /// Whether the [Player] has stopped for buffering.
   final Stream<bool> buffering;
-
-  /// last buffered Duration of the currently playing [Media] in the [Player].
-  final Stream<Duration> lastBuffered;
 
   /// [Stream] emitting [PlayerLog]s.
   final Stream<PlayerLog> log;
@@ -89,11 +90,11 @@ class PlayerStreams {
     this.completed,
     this.position,
     this.duration,
+    this.buffer,
     this.volume,
     this.rate,
     this.pitch,
     this.buffering,
-    this.lastBuffered,
     this.log,
     this.error,
     this.audioParams,

--- a/media_kit/lib/src/models/player_streams.dart
+++ b/media_kit/lib/src/models/player_streams.dart
@@ -47,6 +47,9 @@ class PlayerStreams {
   /// Whether the [Player] has stopped for buffering.
   final Stream<bool> buffering;
 
+  /// last buffered Duration of the currently playing [Media] in the [Player].
+  final Stream<Duration> lastBuffered;
+
   /// [Stream] emitting [PlayerLog]s.
   final Stream<PlayerLog> log;
 
@@ -90,6 +93,7 @@ class PlayerStreams {
     this.rate,
     this.pitch,
     this.buffering,
+    this.lastBuffered,
     this.log,
     this.error,
     this.audioParams,

--- a/media_kit/lib/src/platform_player.dart
+++ b/media_kit/lib/src/platform_player.dart
@@ -151,6 +151,7 @@ abstract class PlatformPlayer {
     rateController.stream,
     pitchController.stream,
     bufferingController.stream,
+    lastBufferedController.stream,
     logController.stream,
     errorController.stream,
     audioParamsController.stream,
@@ -175,6 +176,7 @@ abstract class PlatformPlayer {
           rateController.close(),
           pitchController.close(),
           bufferingController.close(),
+          lastBufferedController.close(),
           logController.close(),
           errorController.close(),
           audioParamsController.close(),
@@ -353,6 +355,10 @@ abstract class PlatformPlayer {
   @protected
   final StreamController<bool> bufferingController =
       StreamController<bool>.broadcast();
+
+  @protected
+  final StreamController<Duration> lastBufferedController =
+      StreamController<Duration>.broadcast();
 
   @protected
   final StreamController<PlayerLog> logController =

--- a/media_kit/lib/src/platform_player.dart
+++ b/media_kit/lib/src/platform_player.dart
@@ -147,11 +147,11 @@ abstract class PlatformPlayer {
     completedController.stream,
     positionController.stream,
     durationController.stream,
+    bufferController.stream,
     volumeController.stream,
     rateController.stream,
     pitchController.stream,
     bufferingController.stream,
-    lastBufferedController.stream,
     logController.stream,
     errorController.stream,
     audioParamsController.stream,
@@ -172,11 +172,11 @@ abstract class PlatformPlayer {
           completedController.close(),
           positionController.close(),
           durationController.close(),
+          bufferController.close(),
           volumeController.close(),
           rateController.close(),
           pitchController.close(),
           bufferingController.close(),
-          lastBufferedController.close(),
           logController.close(),
           errorController.close(),
           audioParamsController.close(),
@@ -341,6 +341,10 @@ abstract class PlatformPlayer {
       StreamController.broadcast();
 
   @protected
+  final StreamController<Duration> bufferController =
+      StreamController<Duration>.broadcast();
+
+  @protected
   final StreamController<double> volumeController =
       StreamController.broadcast();
 
@@ -355,10 +359,6 @@ abstract class PlatformPlayer {
   @protected
   final StreamController<bool> bufferingController =
       StreamController<bool>.broadcast();
-
-  @protected
-  final StreamController<Duration> lastBufferedController =
-      StreamController<Duration>.broadcast();
 
   @protected
   final StreamController<PlayerLog> logController =

--- a/media_kit_test/lib/common/widgets.dart
+++ b/media_kit_test/lib/common/widgets.dart
@@ -139,7 +139,7 @@ class _SeekBarState extends State<SeekBar> {
   bool seeking = false;
   Duration position = Duration.zero;
   Duration duration = Duration.zero;
-  Duration lastBuffered = Duration.zero;
+  Duration buffer = Duration.zero;
 
   List<StreamSubscription> subscriptions = [];
 
@@ -149,7 +149,7 @@ class _SeekBarState extends State<SeekBar> {
     playing = widget.player.state.playing;
     position = widget.player.state.position;
     duration = widget.player.state.duration;
-    lastBuffered = widget.player.state.lastBuffered;
+    buffer = widget.player.state.buffer;
     subscriptions.addAll(
       [
         widget.player.streams.playing.listen((event) {
@@ -172,9 +172,9 @@ class _SeekBarState extends State<SeekBar> {
             duration = event;
           });
         }),
-        widget.player.streams.lastBuffered.listen((event) {
+        widget.player.streams.buffer.listen((event) {
           setState(() {
-            lastBuffered = event;
+            buffer = event;
           });
         }),
       ],
@@ -239,10 +239,13 @@ class _SeekBarState extends State<SeekBar> {
                 min: 0.0,
                 max: duration.inMilliseconds.toDouble(),
                 value: position.inMilliseconds.toDouble().clamp(
-                      0,
+                      0.0,
                       duration.inMilliseconds.toDouble(),
                     ),
-                secondaryTrackValue: lastBuffered.inMilliseconds.toDouble(),
+                secondaryTrackValue: buffer.inMilliseconds.toDouble().clamp(
+                      0.0,
+                      duration.inMilliseconds.toDouble(),
+                    ),
                 onChangeStart: (e) {
                   seeking = true;
                 },

--- a/media_kit_test/lib/common/widgets.dart
+++ b/media_kit_test/lib/common/widgets.dart
@@ -139,6 +139,7 @@ class _SeekBarState extends State<SeekBar> {
   bool seeking = false;
   Duration position = Duration.zero;
   Duration duration = Duration.zero;
+  Duration lastBuffered = Duration.zero;
 
   List<StreamSubscription> subscriptions = [];
 
@@ -148,6 +149,7 @@ class _SeekBarState extends State<SeekBar> {
     playing = widget.player.state.playing;
     position = widget.player.state.position;
     duration = widget.player.state.duration;
+    lastBuffered = widget.player.state.lastBuffered;
     subscriptions.addAll(
       [
         widget.player.streams.playing.listen((event) {
@@ -168,6 +170,11 @@ class _SeekBarState extends State<SeekBar> {
         widget.player.streams.duration.listen((event) {
           setState(() {
             duration = event;
+          });
+        }),
+        widget.player.streams.lastBuffered.listen((event) {
+          setState(() {
+            lastBuffered = event;
           });
         }),
       ],
@@ -235,6 +242,7 @@ class _SeekBarState extends State<SeekBar> {
                       0,
                       duration.inMilliseconds.toDouble(),
                     ),
+                secondaryTrackValue: lastBuffered.inMilliseconds.toDouble(),
                 onChangeStart: (e) {
                   seeking = true;
                 },


### PR DESCRIPTION
Added functionality to retrieve the last buffered placement in the player and implemented the necessary logic in the media_kit_test to test the changes. Please refer to the attached photo for reference.

Changes Made:

- Added code to retrieve the last buffered placement in the player.
- Implemented logic in the media_kit_test to test the changes.
- Attached a photo for reference.

### Note: tested on windows

![image](https://user-images.githubusercontent.com/25157308/231313569-d343f7a4-1973-4e3c-a3a0-8e5539849a98.png)
