### PR TITLE
feat: variable buffer size

### DIFF
--- a/media_kit/lib/src/libmpv/player.dart
+++ b/media_kit/lib/src/libmpv/player.dart
@@ -1161,7 +1161,7 @@ class Player extends PlatformPlayer {
     }
     {
       final name = 'demuxer-max-bytes'.toNativeUtf8();
-      final value = (32 * 1024 * 1024).toString().toNativeUtf8();
+      final value = configuration.bufferSize.toString().toNativeUtf8();
       _libmpv?.mpv_set_property_string(
         result,
         name.cast(),

--- a/media_kit/lib/src/platform_player.dart
+++ b/media_kit/lib/src/platform_player.dart
@@ -101,6 +101,14 @@ class PlayerConfiguration {
   /// Default: `null`.
   final String? title;
 
+  /// This controls how much the demuxer is allowed to buffer ahead in bytes.
+  /// This is useful for network streams, where it can prevent playback
+  /// from stalling or consuming too much bandwidth.
+  ///
+  /// Default: `32` MB or `32 * 1024 * 1024` bytes.
+  ///
+  final int bufferSize;
+
   /// Optional callback invoked when the internals of the [Player] are initialized & ready for playback.
   ///
   /// Default: `null`.
@@ -116,8 +124,9 @@ class PlayerConfiguration {
     this.pitch = false,
     this.libmpv,
     this.title,
+    this.bufferSize = 32 * 1024 * 1024,
     this.ready,
-  });
+  }) : assert(bufferSize > 0, 'bufferSize must be greater than 0');
 }
 
 /// {@template platform_player}

--- a/media_kit_test/lib/common/widgets.dart
+++ b/media_kit_test/lib/common/widgets.dart
@@ -191,12 +191,12 @@ class _SeekBarState extends State<SeekBar> {
 
   @override
   Widget build(BuildContext context) {
-    final horiontal =
+    final horizontal =
         MediaQuery.of(context).size.width > MediaQuery.of(context).size.height;
     return Column(
       children: [
         const SizedBox(height: 16.0),
-        if (horiontal)
+        if (horizontal)
           Row(
             children: [
               const Spacer(),
@@ -222,7 +222,7 @@ class _SeekBarState extends State<SeekBar> {
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             const SizedBox(width: 48.0),
-            if (horiontal) ...[
+            if (horizontal) ...[
               IconButton(
                 onPressed: widget.player.playOrPause,
                 icon: Icon(

--- a/media_kit_test/lib/tests/01.single_player_single_video.dart
+++ b/media_kit_test/lib/tests/01.single_player_single_video.dart
@@ -20,6 +20,7 @@ class _SinglePlayerSingleVideoScreenState
   final Player player = Player(
     configuration: const PlayerConfiguration(
       logLevel: MPVLogLevel.warn,
+      // bufferSize: 1 << 20, // 1 MiB of buffer
     ),
   );
   VideoController? controller;


### PR DESCRIPTION
Added this functionality to complement [zezo357](https://github.com/zezo357)'s PR (#123) adding the ability to control MPV [demuxer-max-bytes](demuxer-max-bytes) argument which is previously was fixed to `32 MB`.
This is useful for network streams, where it can prevent playback from stalling or consuming too much bandwidth.

Changes made:
- Added `bufferSize` to `PlayerConfiguration` with the default value of `32 MB`.
- Updated test example with the new configuration argument.

## Tested on macOS
Tested video [here](http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4).

### Using the default `32 MB` buffer size
![Screen Shot 2023-04-13 at 3 04 36 AM](https://user-images.githubusercontent.com/56558577/231619186-69434c21-45bb-4500-afd1-2c64730eae5a.png)

### Using `5 MB` buffer size
![Screen Shot 2023-04-13 at 3 05 24 AM](https://user-images.githubusercontent.com/56558577/231619279-287d0ab7-0f31-4d3a-89b7-83276ff9d0d9.png)
