### PR TITLE
fix(android): bump dependencies

### DIFF
--- a/media_kit_libs_android_audio/android/build.gradle
+++ b/media_kit_libs_android_audio/android/build.gradle
@@ -44,13 +44,15 @@ android {
 task downloadDependencies(type: Exec) {
     println "media_kit: Downloading dependencies..."
 
-    def urlARM64 = "https://github.com/media-kit/android-dependencies/releases/download/v0.0.1/audio-arm64-v8a.jar"
-    def urlARMEABI = "https://github.com/media-kit/android-dependencies/releases/download/v0.0.1/audio-armeabi-v7a.jar"
-    def urlX86_64 = "https://github.com/media-kit/android-dependencies/releases/download/v0.0.1/audio-x86_64.jar"
+    def urlARM64 = "https://github.com/media-kit/android-dependencies/releases/download/v0.0.3/audio-arm64-v8a.jar"
+    def urlARMEABI = "https://github.com/media-kit/android-dependencies/releases/download/v0.0.3/audio-armeabi-v7a.jar"
+    def urlX86_64 = "https://github.com/media-kit/android-dependencies/releases/download/v0.0.3/audio-x86_64.jar"
+    def urlX86 = "https://github.com/media-kit/android-dependencies/releases/download/v0.0.3/audio-x86.jar"
 
     def destARM64 = file("$buildDir/audio-arm64-v8a.jar")
     def destARMEABI = file("$buildDir/audio-armeabi-v7a.jar")
     def destX86_64 = file("$buildDir/audio-x86_64.jar")
+    def destX86 = file("$buildDir/audio-x86.jar")
 
     if (!destARM64.exists()) {
         println "media_kit: Downloading arm64-v8a JAR..."
@@ -73,26 +75,40 @@ task downloadDependencies(type: Exec) {
             os << new URL(urlX86_64).openStream()
         }
     }
+    if (!destX86.exists()) {
+        println "media_kit: Downloading x86 JAR..."
+        destX86.parentFile.mkdirs()
+        destX86.withOutputStream { os ->
+            os << new URL(urlX86).openStream()
+        }
+    }
 
     def md5ARM64 = MessageDigest.getInstance("MD5").digest(Files.readAllBytes(destARM64.toPath())).encodeHex().toString().toUpperCase()
     def md5ARMEABI = MessageDigest.getInstance("MD5").digest(Files.readAllBytes(destARMEABI.toPath())).encodeHex().toString().toUpperCase()
     def md5X86_64 = MessageDigest.getInstance("MD5").digest(Files.readAllBytes(destX86_64.toPath())).encodeHex().toString().toUpperCase()
+    def md5X86 = MessageDigest.getInstance("MD5").digest(Files.readAllBytes(destX86.toPath())).encodeHex().toString().toUpperCase()
 
-    if (md5ARM64 != "73F6B522DA05423A97EF0DE9ED73A9BB") {
-        throw new GradleException("media_kit: arm64-v8a JAR integrity check failed.")
+    if (md5ARM64 != "5223EF27AC457E2DBC931DB484A95935") {
+        throw new GradleException("media_kit: arm64-v8a JAR verification failed.")
     } else {
-        println "media_kit: arm64-v8a JAR integrity check successful."
+        println "media_kit: arm64-v8a JAR verification successful."
     }
-    if (md5ARMEABI != "41FB84ABDA8AC73B5A05B9D162402202") {
-        throw new GradleException("media_kit: armeabi-v7a JAR integrity check failed.")
+    if (md5ARMEABI != "D547EEE9B25661B56B0989AC74FFB6EA") {
+        throw new GradleException("media_kit: armeabi-v7a JAR verification failed.")
     } else {
-        println "media_kit: armeabi-v7a JAR integrity check successful."
+        println "media_kit: armeabi-v7a JAR verification successful."
     }
-    if (md5X86_64 != "35244C860221F5C18D1CBF6DCE1254C6") {
-        throw new GradleException("media_kit: x86_64 JAR integrity check failed.")
+    if (md5X86_64 != "EC2F1DF85B0709957599B0A3FAF3E84D") {
+        throw new GradleException("media_kit: x86_64 JAR verification failed.")
     } else {
-        println "media_kit: x86_64 JAR integrity check successful."
+        println "media_kit: x86_64 JAR verification successful."
     }
+    if (md5X86 != "C54F5FEA79723AB8B6E93D2FE608E5CD") {
+        throw new GradleException("media_kit: x86 JAR verification failed.")
+    } else {
+        println "media_kit: x86 JAR verification successful."
+    }
+
     println "media_kit: Dependencies downloaded successfully."
 }
 

--- a/media_kit_libs_android_video/android/build.gradle
+++ b/media_kit_libs_android_video/android/build.gradle
@@ -44,13 +44,15 @@ android {
 task downloadDependencies(type: Exec) {
     println "media_kit: Downloading dependencies..."
 
-    def urlARM64 = "https://github.com/media-kit/android-dependencies/releases/download/v0.0.1/video-arm64-v8a.jar"
-    def urlARMEABI = "https://github.com/media-kit/android-dependencies/releases/download/v0.0.1/video-armeabi-v7a.jar"
-    def urlX86_64 = "https://github.com/media-kit/android-dependencies/releases/download/v0.0.1/video-x86_64.jar"
+    def urlARM64 = "https://github.com/media-kit/android-dependencies/releases/download/v0.0.3/video-arm64-v8a.jar"
+    def urlARMEABI = "https://github.com/media-kit/android-dependencies/releases/download/v0.0.3/video-armeabi-v7a.jar"
+    def urlX86_64 = "https://github.com/media-kit/android-dependencies/releases/download/v0.0.3/video-x86_64.jar"
+    def urlX86 = "https://github.com/media-kit/android-dependencies/releases/download/v0.0.3/video-x86.jar"
 
     def destARM64 = file("$buildDir/video-arm64-v8a.jar")
     def destARMEABI = file("$buildDir/video-armeabi-v7a.jar")
     def destX86_64 = file("$buildDir/video-x86_64.jar")
+    def destX86 = file("$buildDir/video-x86.jar")
 
     if (!destARM64.exists()) {
         println "media_kit: Downloading arm64-v8a JAR..."
@@ -73,26 +75,40 @@ task downloadDependencies(type: Exec) {
             os << new URL(urlX86_64).openStream()
         }
     }
+    if (!destX86.exists()) {
+        println "media_kit: Downloading x86 JAR..."
+        destX86.parentFile.mkdirs()
+        destX86.withOutputStream { os ->
+            os << new URL(urlX86).openStream()
+        }
+    }
 
     def md5ARM64 = MessageDigest.getInstance("MD5").digest(Files.readAllBytes(destARM64.toPath())).encodeHex().toString().toUpperCase()
     def md5ARMEABI = MessageDigest.getInstance("MD5").digest(Files.readAllBytes(destARMEABI.toPath())).encodeHex().toString().toUpperCase()
     def md5X86_64 = MessageDigest.getInstance("MD5").digest(Files.readAllBytes(destX86_64.toPath())).encodeHex().toString().toUpperCase()
+    def md5X86 = MessageDigest.getInstance("MD5").digest(Files.readAllBytes(destX86.toPath())).encodeHex().toString().toUpperCase()
 
-    if (md5ARM64 != "4167312040B58A2FEC114C4120ADD2A6") {
-        throw new GradleException("media_kit: arm64-v8a JAR integrity check failed.")
+    if (md5ARM64 != "D314CD953E4D2FA4A06E6788873DC185") {
+        throw new GradleException("media_kit: arm64-v8a JAR verification failed.")
     } else {
-        println "media_kit: arm64-v8a JAR integrity check successful."
+        println "media_kit: arm64-v8a JAR verification successful."
     }
-    if (md5ARMEABI != "8143865E9C8492D771583DCEA0230095") {
-        throw new GradleException("media_kit: armeabi-v7a JAR integrity check failed.")
+    if (md5ARMEABI != "638FDBB3BD6EEFAF1B27B5A107856970") {
+        throw new GradleException("media_kit: armeabi-v7a JAR verification failed.")
     } else {
-        println "media_kit: armeabi-v7a JAR integrity check successful."
+        println "media_kit: armeabi-v7a JAR verification successful."
     }
-    if (md5X86_64 != "56E570DFE9DA8741B90EB61E5B42166A") {
-        throw new GradleException("media_kit: x86_64 JAR integrity check failed.")
+    if (md5X86_64 != "C54ACDC9DFA5EFD377211E8CC48AD98C") {
+        throw new GradleException("media_kit: x86_64 JAR verification failed.")
     } else {
-        println "media_kit: x86_64 JAR integrity check successful."
+        println "media_kit: x86_64 JAR verification successful."
     }
+    if (md5X86 != "5D12F79C4C079D101CE575C98EFCC3CD") {
+        throw new GradleException("media_kit: x86 JAR verification failed.")
+    } else {
+        println "media_kit: x86 JAR verification successful."
+    }
+
     println "media_kit: Dependencies downloaded successfully."
 }
 


### PR DESCRIPTION
- Support for Android <= 8.0.
- Add support for x86 (only emulators /w Flutter).
- Upgrade media_kit_native_event_loop shared object from dbbf48819f577e3289d645b66443f0add2773c48.