### PR TITLE
feat/refactor: entry-point API

### DIFF
--- a/media_kit/lib/media_kit.dart
+++ b/media_kit/lib/media_kit.dart
@@ -7,6 +7,7 @@
 // ignore_for_file: camel_case_types
 
 export 'package:media_kit/src/player.dart';
+export 'package:media_kit/src/media_kit.dart';
 export 'package:media_kit/src/platform_player.dart';
 
 export 'package:media_kit/src/models/media.dart';
@@ -18,8 +19,6 @@ export 'package:media_kit/src/models/playlist_mode.dart';
 
 // For invoking platform specific API.
 
-import 'package:media_kit/src/libmpv/player.dart' as libmpv;
-import 'package:media_kit/src/libmpv/core/native_library.dart' as libmpv;
+import 'package:media_kit/src/libmpv/player.dart' as _libmpv;
 
-typedef libmpvPlayer = libmpv.Player;
-typedef libmpvNativeLibrary = libmpv.NativeLibrary;
+typedef libmpvPlayer = _libmpv.Player;

--- a/media_kit/lib/src/android_asset_loader.dart
+++ b/media_kit/lib/src/android_asset_loader.dart
@@ -7,16 +7,6 @@ import 'dart:io';
 import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 
-// Type definitions for native functions in the shared library.
-
-// C/C++:
-
-typedef FnCXX = Void Function(Pointer<Utf8> asset, Pointer<Utf8> result);
-
-// Dart:
-
-typedef FnDart = void Function(Pointer<Utf8> asset, Pointer<Utf8> result);
-
 /// {@template android_asset_loader}
 ///
 /// AndroidAssetLoader
@@ -64,3 +54,13 @@ class AndroidAssetLoader {
 
   FnDart? _mediaKitAndroidHelperCopyAssetToExternalFilesDir;
 }
+
+// Type definitions for native functions in the shared library.
+
+// C/C++:
+
+typedef FnCXX = Void Function(Pointer<Utf8> asset, Pointer<Utf8> result);
+
+// Dart:
+
+typedef FnDart = void Function(Pointer<Utf8> asset, Pointer<Utf8> result);

--- a/media_kit/lib/src/libmpv/core/initializer.dart
+++ b/media_kit/lib/src/libmpv/core/initializer.dart
@@ -2,8 +2,8 @@ import 'dart:ffi';
 
 import 'package:media_kit/generated/libmpv/bindings.dart';
 
-import 'initializer_isolate.dart' as initializer_isolate;
-import 'initializer_native_event_loop.dart' as initializer_native_event_loop;
+import 'initializer_isolate.dart';
+import 'initializer_native_event_loop.dart';
 
 /// Creates & returns initialized [Pointer] to [mpv_handle].
 /// Pass [path] to libmpv dynamic library & [callback] to receive event callbacks as [Pointer] to [mpv_event].
@@ -12,12 +12,12 @@ import 'initializer_native_event_loop.dart' as initializer_native_event_loop;
 /// See package:media_kit_native_event_loop for more details.
 ///
 Future<Pointer<mpv_handle>> create(
-  String? path,
+  String path,
   Future<void> Function(Pointer<mpv_event> event)? callback,
 ) async {
   try {
-    return await initializer_native_event_loop.create(path, callback);
+    return await InitializerNativeEventLoop.create(path, callback);
   } catch (exception) {
-    return await initializer_isolate.create(path, callback);
+    return await InitializerIsolate.create(path, callback);
   }
 }

--- a/media_kit/lib/src/libmpv/core/initializer_isolate.dart
+++ b/media_kit/lib/src/libmpv/core/initializer_isolate.dart
@@ -9,113 +9,114 @@ import 'dart:async';
 import 'dart:isolate';
 
 import 'package:media_kit/generated/libmpv/bindings.dart';
-import 'package:media_kit/src/libmpv/core/native_library.dart';
 
-/// Detect if app running in release mode.
-const isReleaseMode = bool.fromEnvironment('dart.vm.product');
-
-/// Runs on separate isolate.
-/// Calls [MPV.mpv_create] & [MPV.mpv_initialize] to create a new [mpv_handle].
-/// Uses [MPV.mpv_wait_event] to wait for the next event & notifies through the passed [SendPort] as the argument.
+/// InitializerIsolate
+/// ------------------
 ///
-/// First value sent through the [SendPort] is [SendPort] of the internal [ReceivePort].
-/// Second value sent through the [SendPort] is raw address of the [Pointer] to [mpv_handle] created by the isolate.
-/// Subsequent sent values are [Pointer] to [mpv_event].
-///
-void mainloop(SendPort port) async {
-  // Used to ensure that the last [mpv_event] is NOT reset to [mpv_event_id.MPV_EVENT_NONE] after waiting using [MPV.mpv_wait_event] again in the continuously running while loop.
-  var completer = Completer();
-  // Used to recieve the confirmation messages from the main thread about successful receive of the sent event through [SendPort].
-  // Upon confirmation, the [Completer] is completed & we jump to next iteration of the while loop waiting with [MPV.mpv_wait_event].
-  final receiver = ReceivePort();
-  // Send the [SendPort] of internal [ReceivePort].
-  port.send(receiver.sendPort);
-  // Separately creating [MPV] object since isolates don't share finaliables.
-  late MPV mpv;
-  receiver.listen((message) {
-    // Initializing the local [MPV] object.
-    if (message == null) {
-      mpv = MPV(NativeLibrary.find());
-    } else if (message is String) {
-      mpv = MPV(DynamicLibrary.open(message));
-    }
-    // Notifying about the successful sending of the event & move onto next [MPV.mpv_wait_event] after completing the [Completer].
-    completer.complete();
-  });
-  // Waiting for [MPV] to be late initialized.
-  await completer.future;
-  // Creating & initializing [mpv_handle].
-  final handle = mpv.mpv_create();
-  mpv.mpv_initialize(handle);
-  // Sending the address of the created [mpv_handle] & the [SendPort] of the [receivePort].
-  // Raw address is sent as [int] since we cannot transfer objects through Native Ports, only primatives.
-  port.send(handle.address);
-  // Lookup for events & send to main thread through [SendPort].
-  // Ensuring the successful sending of the last event before moving to next [MPV.mpv_wait_event].
-  while (true) {
-    completer = Completer();
-    final event = mpv.mpv_wait_event(handle, isReleaseMode ? -1 : 0.1);
-    // Sending raw address of [mpv_event].
-    port.send(event.address);
-    // Ensuring that the last [mpv_event] (which is at the same address) is NOT reset to [mpv_event_id.MPV_EVENT_NONE] after next [MPV.mpv_wait_event] in the loop.
-    await completer.future;
-    if (event.ref.event_id == mpv_event_id.MPV_EVENT_SHUTDOWN) {
-      break;
+/// Creates & returns initialized [Pointer] to [mpv_handle] whose event loop is running on separate isolate.
+abstract class InitializerIsolate {
+  /// Creates & returns initialized [Pointer] to [mpv_handle] whose event loop is running on separate isolate.
+  static Future<Pointer<mpv_handle>> create(
+    String path,
+    Future<void> Function(Pointer<mpv_event> event)? callback,
+  ) async {
+    if (callback == null) {
+      // No requirement for separate isolate.
+      final mpv = MPV(DynamicLibrary.open(path));
+      final handle = mpv.mpv_create();
+      mpv.mpv_initialize(handle);
+      return handle;
+    } else {
+      // Used to wait for retrieval of [Pointer] to [mpv_handle] from the running isolate.
+      final completer = Completer();
+      // Used to receive events from the separate isolate.
+      final receiver = ReceivePort();
+      // Late initialized [mpv_handle] & [SendPort] of the [ReceievePort] inside the separate isolate.
+      late Pointer<mpv_handle> handle;
+      late SendPort port;
+      // Run mainloop in the separate isolate.
+      await Isolate.spawn(
+        _mainloop,
+        receiver.sendPort,
+      );
+      receiver.listen((message) async {
+        // Receiving [SendPort] of the [ReceivePort] inside the separate isolate to send the path to [DynamicLibrary].
+        if (!completer.isCompleted && message is SendPort) {
+          port = message;
+          port.send(path);
+        }
+        // Receiving [Pointer] to [mpv_handle] created by separate isolate.
+        else if (!completer.isCompleted && message is int) {
+          handle = Pointer.fromAddress(message);
+          completer.complete();
+        }
+        // Receiving event callbacks.
+        else {
+          Pointer<mpv_event> event = Pointer.fromAddress(message);
+          try {
+            await callback(event);
+          } catch (exception, stacktrace) {
+            print(exception.toString());
+            print(stacktrace.toString());
+          }
+          port.send(true);
+        }
+      });
+      // Awaiting the retrieval of [Pointer] to [mpv_handle].
+      await completer.future;
+      return handle;
     }
   }
-}
 
-/// Creates & returns initialized [Pointer] to [mpv_handle] whose event loop is running on separate isolate.
-Future<Pointer<mpv_handle>> create(
-  String? path,
-  Future<void> Function(Pointer<mpv_event> event)? callback,
-) async {
-  if (callback == null) {
-    // No requirement for separate isolate.
-    final mpv = MPV(
-      path == null ? NativeLibrary.find() : DynamicLibrary.open(path),
-    );
+  /// Detect if app running in release mode.
+  static const _isReleaseMode = bool.fromEnvironment('dart.vm.product');
+
+  /// Runs on separate isolate.
+  /// Calls [MPV.mpv_create] & [MPV.mpv_initialize] to create a new [mpv_handle].
+  /// Uses [MPV.mpv_wait_event] to wait for the next event & notifies through the passed [SendPort] as the argument.
+  ///
+  /// First value sent through the [SendPort] is [SendPort] of the internal [ReceivePort].
+  /// Second value sent through the [SendPort] is raw address of the [Pointer] to [mpv_handle] created by the isolate.
+  /// Subsequent sent values are [Pointer] to [mpv_event].
+  @pragma('vm:entry-point')
+  static void _mainloop(SendPort port) async {
+    // Used to ensure that the last [mpv_event] is NOT reset to [mpv_event_id.MPV_EVENT_NONE] after waiting using [MPV.mpv_wait_event] again in the continuously running while loop.
+    var completer = Completer();
+    // Used to recieve the confirmation messages from the main thread about successful receive of the sent event through [SendPort].
+    // Upon confirmation, the [Completer] is completed & we jump to next iteration of the while loop waiting with [MPV.mpv_wait_event].
+    final receiver = ReceivePort();
+    // Send the [SendPort] of internal [ReceivePort].
+    port.send(receiver.sendPort);
+    // Separately creating [MPV] object since isolates don't share finaliables.
+    late MPV mpv;
+    receiver.listen((message) {
+      // Initializing the local [MPV] object.
+      if (message is String) {
+        mpv = MPV(DynamicLibrary.open(message));
+      }
+      // Notifying about the successful sending of the event & move onto next [MPV.mpv_wait_event] after completing the [Completer].
+      completer.complete();
+    });
+    // Waiting for [MPV] to be late initialized.
+    await completer.future;
+    // Creating & initializing [mpv_handle].
     final handle = mpv.mpv_create();
     mpv.mpv_initialize(handle);
-    return handle;
-  } else {
-    // Used to wait for retrieval of [Pointer] to [mpv_handle] from the running isolate.
-    final completer = Completer();
-    // Used to receive events from the separate isolate.
-    final receiver = ReceivePort();
-    // Late initialized [mpv_handle] & [SendPort] of the [ReceievePort] inside the separate isolate.
-    late Pointer<mpv_handle> handle;
-    late SendPort port;
-    // Run mainloop in the separate isolate.
-    await Isolate.spawn(
-      mainloop,
-      receiver.sendPort,
-    );
-    receiver.listen((message) async {
-      // Receiving [SendPort] of the [ReceivePort] inside the separate isolate to send the path to [DynamicLibrary].
-      if (!completer.isCompleted && message is SendPort) {
-        port = message;
-        port.send(path);
+    // Sending the address of the created [mpv_handle] & the [SendPort] of the [receivePort].
+    // Raw address is sent as [int] since we cannot transfer objects through Native Ports, only primatives.
+    port.send(handle.address);
+    // Lookup for events & send to main thread through [SendPort].
+    // Ensuring the successful sending of the last event before moving to next [MPV.mpv_wait_event].
+    while (true) {
+      completer = Completer();
+      final event = mpv.mpv_wait_event(handle, _isReleaseMode ? -1 : 0.1);
+      // Sending raw address of [mpv_event].
+      port.send(event.address);
+      // Ensuring that the last [mpv_event] (which is at the same address) is NOT reset to [mpv_event_id.MPV_EVENT_NONE] after next [MPV.mpv_wait_event] in the loop.
+      await completer.future;
+      if (event.ref.event_id == mpv_event_id.MPV_EVENT_SHUTDOWN) {
+        break;
       }
-      // Receiving [Pointer] to [mpv_handle] created by separate isolate.
-      else if (!completer.isCompleted && message is int) {
-        handle = Pointer.fromAddress(message);
-        completer.complete();
-      }
-      // Receiving event callbacks.
-      else {
-        Pointer<mpv_event> event = Pointer.fromAddress(message);
-        try {
-          await callback(event);
-        } catch (exception, stacktrace) {
-          print(exception.toString());
-          print(stacktrace.toString());
-        }
-        port.send(true);
-      }
-    });
-    // Awaiting the retrieval of [Pointer] to [mpv_handle].
-    await completer.future;
-    return handle;
+    }
   }
 }

--- a/media_kit/lib/src/libmpv/core/initializer_native_event_loop.dart
+++ b/media_kit/lib/src/libmpv/core/initializer_native_event_loop.dart
@@ -4,8 +4,6 @@
 /// All rights reserved.
 /// Use of this source code is governed by MIT license that can be found in the LICENSE file.
 
-// ignore_for_file: non_constant_identifier_names, unused_local_variable, camel_case_types
-
 import 'dart:io';
 import 'dart:ffi';
 import 'dart:async';
@@ -13,21 +11,131 @@ import 'dart:isolate';
 import 'dart:collection';
 
 import 'package:media_kit/generated/libmpv/bindings.dart';
-import 'package:media_kit/src/libmpv/core/native_library.dart';
 
-/// Name of the shared library used for platform specific threaded event handling.
+/// InitializerNativeEventLoop
+/// --------------------------
+///
+/// Creates & returns initialized [Pointer] to [mpv_handle] whose event loop is running on native thread.
 ///
 /// See:
-/// https://github.com/alexmercerind/media_kit/issues/40
-/// https://github.com/alexmercerind/media_kit/pull/46
-/// https://github.com/dart-lang/sdk/issues/51254
-/// https://github.com/dart-lang/sdk/issues/51261
-const kNativeEventLoopDynamicLibrary = 'media_kit_native_event_loop';
+/// * https://github.com/alexmercerind/media_kit/issues/40
+/// * https://github.com/alexmercerind/media_kit/pull/46
+/// * https://github.com/dart-lang/sdk/issues/51254
+/// * https://github.com/dart-lang/sdk/issues/51261
+///
+abstract class InitializerNativeEventLoop {
+  /// Initializes the |InitializerNativeEventLoop| class for usage.
+  static void ensureInitialized() {
+    try {
+      final dylib = () {
+        if (Platform.isMacOS || Platform.isIOS) {
+          return DynamicLibrary.open(
+            'media_kit_native_event_loop.framework/media_kit_native_event_loop',
+          );
+        }
+        if (Platform.isAndroid || Platform.isLinux) {
+          return DynamicLibrary.open('libmedia_kit_native_event_loop.so');
+        }
+        if (Platform.isWindows) {
+          return DynamicLibrary.open('media_kit_native_event_loop.dll');
+        }
+      }()!;
+      _initialize = dylib.lookupFunction<MediaKitEventLoopHandlerInitializeCXX,
+          MediaKitEventLoopHandlerInitializeDart>(
+        'MediaKitEventLoopHandlerInitialize',
+      );
+      _register = dylib.lookupFunction<MediaKitEventLoopHandlerRegisterCXX,
+          MediaKitEventLoopHandlerRegisterDart>(
+        'MediaKitEventLoopHandlerRegister',
+      );
+      _notify = dylib.lookupFunction<MediaKitEventLoopHandlerNotifyCXX,
+          MediaKitEventLoopHandlerNotifyDart>(
+        'MediaKitEventLoopHandlerNotify',
+      );
+
+      // Initialize the native event loop handler.
+      _initialize?.call();
+    } catch (exception) {
+      print(
+        'media_kit: WARNING: package:media_kit_native_event_loop not found.',
+      );
+    }
+  }
+
+  /// Creates & returns initialized [Pointer] to [mpv_handle] whose event loop is running on native thread.
+  static Future<Pointer<mpv_handle>> create(
+    String path,
+    Future<void> Function(Pointer<mpv_event> event)? callback,
+  ) async {
+    // Native functions from the shared library should be resolved by now.
+    // If not, throw an exception.
+    // Primarily, this will happen when the shared library is not found i.e. package:media_kit_native_event_loop is not installed.
+    if (_register == null || _notify == null) {
+      throw Exception(
+        'package:media_kit_native_event_loop shared library not loaded.',
+      );
+    }
+
+    // Create [mpv_handle] & initialize it.
+    final mpv = MPV(DynamicLibrary.open(path));
+
+    final handle = mpv.mpv_create();
+    mpv.mpv_initialize(handle);
+
+    // Only register for event callbacks if [callback] is not null.
+    if (callback != null) {
+      // Save [callback] to invoke it inside [ReceivePort] listener.
+      _callbacks[handle.address] = callback;
+      // Register event callback.
+      _register?.call(
+        handle.address,
+        NativeApi.postCObject.cast(),
+        _receiver.sendPort.nativePort,
+      );
+    }
+
+    return handle;
+  }
+
+  /// [ReceivePort] used to listen for `mpv_event`(s) from the native event loop.
+  /// A single [ReceivePort] is used for multiple instances.
+  static final _receiver = ReceivePort()
+    ..listen(
+      (dynamic message) async {
+        try {
+          final handle = message[0] as int;
+          final event = Pointer<mpv_event>.fromAddress(message[1]);
+          if (event.ref.event_id == mpv_event_id.MPV_EVENT_SHUTDOWN) {
+            _callbacks.remove(handle);
+          } else {
+            // Notify public event handler.
+            await _callbacks[handle]?.call(event);
+          }
+        } catch (exception, stacktrace) {
+          print(exception);
+          print(stacktrace);
+        }
+        // Notify native event loop that event has been handled & it is safe to move onto next `mpv_wait_event`.
+        _notify?.call(message[0]);
+      },
+    );
+
+  // Registered [callback]s to receive [mpv_event](s) from the native event loop.
+  static final _callbacks =
+      HashMap<int, Future<void> Function(Pointer<mpv_event>)>();
+
+  // Resolved native functions from the shared library:
+
+  static MediaKitEventLoopHandlerInitializeDart? _initialize;
+  static MediaKitEventLoopHandlerRegisterDart? _register;
+  static MediaKitEventLoopHandlerNotifyDart? _notify;
+}
 
 // Type definitions for native functions in the shared library.
 
 // C/C++:
 
+typedef MediaKitEventLoopHandlerInitializeCXX = Void Function();
 typedef MediaKitEventLoopHandlerRegisterCXX = Void Function(
   Int64 handle,
   Pointer<Void> callback,
@@ -37,105 +145,10 @@ typedef MediaKitEventLoopHandlerNotifyCXX = Void Function(Int64 handle);
 
 // Dart:
 
+typedef MediaKitEventLoopHandlerInitializeDart = void Function();
 typedef MediaKitEventLoopHandlerRegisterDart = void Function(
   int handle,
   Pointer<Void> callback,
   int port,
 );
 typedef MediaKitEventLoopHandlerNotifyDart = void Function(int handle);
-
-// Resolved native functions from the shared library.
-MediaKitEventLoopHandlerRegisterDart? MediaKitEventLoopHandlerRegister;
-MediaKitEventLoopHandlerNotifyDart? MediaKitEventLoopHandlerNotify;
-
-// Registered [callback]s to receive [mpv_event](s) from the native event loop.
-final callbacks = HashMap<int, Future<void> Function(Pointer<mpv_event>)>();
-
-/// [ReceivePort] used to listen for `mpv_event`(s) from the native event loop.
-/// A single [ReceivePort] is used for multiple instances.
-final receiver = ReceivePort()
-  ..listen(
-    (dynamic message) async {
-      try {
-        final handle = message[0] as int;
-        final event = Pointer<mpv_event>.fromAddress(message[1]);
-        if (event.ref.event_id == mpv_event_id.MPV_EVENT_SHUTDOWN) {
-          callbacks.remove(handle);
-        } else {
-          // Notify public event handler.
-          await callbacks[handle]?.call(event);
-        }
-      } catch (exception, stacktrace) {
-        print(exception);
-        print(stacktrace);
-      }
-      // Notify native event loop that event has been handled & it is safe to move onto next `mpv_wait_event`.
-      MediaKitEventLoopHandlerNotify?.call(message[0]);
-    },
-  );
-
-/// Creates & returns initialized [Pointer] to [mpv_handle] whose event loop is running on native thread.
-Future<Pointer<mpv_handle>> create(
-  String? path,
-  Future<void> Function(Pointer<mpv_event> event)? callback,
-) async {
-  // Load native functions from the shared library on first call.
-  if (MediaKitEventLoopHandlerRegister == null &&
-      MediaKitEventLoopHandlerNotify == null) {
-    final dylib = () {
-      if (Platform.isMacOS || Platform.isIOS) {
-        return DynamicLibrary.open(
-          '$kNativeEventLoopDynamicLibrary.framework/$kNativeEventLoopDynamicLibrary',
-        );
-      }
-      if (Platform.isAndroid || Platform.isLinux) {
-        return DynamicLibrary.open('lib$kNativeEventLoopDynamicLibrary.so');
-      }
-      if (Platform.isWindows) {
-        return DynamicLibrary.open('$kNativeEventLoopDynamicLibrary.dll');
-      }
-    }();
-    if (dylib != null) {
-      // Load native functions from the dynamic library.
-      MediaKitEventLoopHandlerRegister = dylib.lookupFunction<
-          MediaKitEventLoopHandlerRegisterCXX,
-          MediaKitEventLoopHandlerRegisterDart>(
-        'MediaKitEventLoopHandlerRegister',
-      );
-      MediaKitEventLoopHandlerNotify = dylib.lookupFunction<
-          MediaKitEventLoopHandlerNotifyCXX,
-          MediaKitEventLoopHandlerNotifyDart>(
-        'MediaKitEventLoopHandlerNotify',
-      );
-    }
-  }
-  // Native functions from the shared library should be resolved by now.
-  // If not, throw an exception.
-  // Primarily, this will happen when the shared library is not found i.e. package:media_kit_native_event_loop is not installed.
-  if (MediaKitEventLoopHandlerRegister == null ||
-      MediaKitEventLoopHandlerNotify == null) {
-    throw Exception('Unable to find native event loop shared library.');
-  }
-
-  // Create [mpv_handle] & initialize it.
-  final mpv = MPV(
-    path == null ? NativeLibrary.find() : DynamicLibrary.open(path),
-  );
-  final handle = mpv.mpv_create();
-  mpv.mpv_initialize(handle);
-
-  // Only register for event callbacks if [callback] is not null.
-  if (callback != null) {
-    // Save [callback] to invoke it inside [ReceivePort] listener.
-    callbacks[handle.address] = callback;
-
-    // Register event callback.
-    MediaKitEventLoopHandlerRegister?.call(
-      handle.address,
-      NativeApi.postCObject.cast(),
-      receiver.sendPort.nativePort,
-    );
-  }
-
-  return handle;
-}

--- a/media_kit/lib/src/libmpv/entry_point.dart
+++ b/media_kit/lib/src/libmpv/entry_point.dart
@@ -1,0 +1,16 @@
+/// This file is a part of media_kit (https://github.com/alexmercerind/media_kit).
+///
+/// Copyright © 2021 & onwards, Hitesh Kumar Saini <saini123hitesh@gmail.com>.
+/// All rights reserved.
+/// Use of this source code is governed by MIT license that can be found in the LICENSE file.
+import 'package:media_kit/src/libmpv/core/native_library.dart';
+import 'package:media_kit/src/libmpv/core/initializer_native_event_loop.dart';
+
+/// Initializes the libmpv backend for package:media_kit.
+///
+/// Following optional parameters are available:
+/// * `libmpv`: Manually specified the path to the libmpv shared library.
+void ensureInitialized({String? libmpv}) {
+  NativeLibrary.ensureInitialized(libmpv: libmpv);
+  InitializerNativeEventLoop.ensureInitialized();
+}

--- a/media_kit/lib/src/libmpv/player.dart
+++ b/media_kit/lib/src/libmpv/player.dart
@@ -1118,13 +1118,9 @@ class Player extends PlatformPlayer {
   }
 
   Future<void> _create() async {
-    _libmpv = generated.MPV(NativeLibrary.find(path: configuration.libmpv));
+    _libmpv = generated.MPV(DynamicLibrary.open(NativeLibrary.path));
     // We cannot disable events on Android because they are consumed by package:media_kit_video.
-    final events = Platform.isAndroid ? true : configuration.events;
-    final result = await create(
-      configuration.libmpv,
-      events ? _handler : null,
-    );
+    final result = await create(NativeLibrary.path, _handler);
     // Set:
     // idle = yes
     // pause = yes
@@ -1301,7 +1297,7 @@ class Player extends PlatformPlayer {
       calloc.free(name);
       calloc.free(value);
     }
-    if (events && configuration.logLevel != MPVLogLevel.none) {
+    if (configuration.logLevel != MPVLogLevel.none) {
       // https://github.com/mpv-player/mpv/blob/e1727553f164181265f71a20106fbd5e34fa08b0/libmpv/client.h#L1410-L1419
       final levels = {
         MPVLogLevel.none: 'no',

--- a/media_kit/lib/src/media_kit.dart
+++ b/media_kit/lib/src/media_kit.dart
@@ -1,0 +1,45 @@
+/// This file is a part of media_kit (https://github.com/alexmercerind/media_kit).
+///
+/// Copyright © 2021 & onwards, Hitesh Kumar Saini <saini123hitesh@gmail.com>.
+/// All rights reserved.
+/// Use of this source code is governed by MIT license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:media_kit/src/libmpv/entry_point.dart' as _libmpv;
+
+/// {@template media_kit}
+///
+/// package:media_kit
+/// -----------------
+/// A complete video & audio library for Flutter & Dart.
+///
+/// * GitHub  : https://github.com/alexmercerind/media_kit
+/// * pub.dev : https://pub.dev/packages/media_kit
+///
+/// [MediaKit.ensureInitialized] must be called for using the package.
+///
+/// Following optional parameters are available:
+/// * `libmpv`: Manually specified the path to the libmpv shared library.
+///
+/// {@endtemplate}
+abstract class MediaKit {
+  /// {@macro media_kit}
+  static void ensureInitialized({String? libmpv}) {
+    if (Platform.isWindows) {
+      _libmpv.ensureInitialized();
+    }
+    if (Platform.isLinux) {
+      _libmpv.ensureInitialized();
+    }
+    if (Platform.isMacOS) {
+      _libmpv.ensureInitialized();
+    }
+    if (Platform.isIOS) {
+      _libmpv.ensureInitialized();
+    }
+    if (Platform.isAndroid) {
+      _libmpv.ensureInitialized();
+    }
+  }
+}

--- a/media_kit/lib/src/platform_player.dart
+++ b/media_kit/lib/src/platform_player.dart
@@ -60,10 +60,6 @@ enum MPVLogLevel {
 ///
 /// {@endtemplate}
 class PlayerConfiguration {
-  /// Enables or disables event handling. This may improve performance if there is no need to listen to events.
-  /// Default: `true`.
-  final bool events;
-
   /// Sets the log level on libmpv backend.
   /// Default: `none`.
   final MPVLogLevel logLevel;
@@ -91,11 +87,6 @@ class PlayerConfiguration {
   /// Default: `false`.
   final bool pitch;
 
-  /// Sets manually specified location to the libmpv shared library & overrides the default look-up behavior.
-  ///
-  /// Default: `null`.
-  final String? libmpv;
-
   /// Sets the name of the underlying window & process on libmpv backend. This is visible inside the Windows' volume mixer.
   ///
   /// Default: `null`.
@@ -108,13 +99,11 @@ class PlayerConfiguration {
 
   /// {@macro player_configuration}
   const PlayerConfiguration({
-    this.events = true,
     this.logLevel = MPVLogLevel.none,
     this.osc = false,
     this.vid,
-    this.vo,
+    this.vo = 'null',
     this.pitch = false,
-    this.libmpv,
     this.title,
     this.ready,
   });

--- a/media_kit/lib/src/player.dart
+++ b/media_kit/lib/src/player.dart
@@ -34,9 +34,13 @@ import 'package:media_kit/src/libmpv/player.dart' as libmpv;
 /// ```dart
 /// import 'package:media_kit/media_kit.dart';
 ///
+/// MediaKit.ensureInitialized();
+///
+/// // Create a [Player] instance for audio or video playback.
+///
 /// final player = Player();
 ///
-/// ...
+/// // Subscribe to event streams & listen to updates.
 ///
 /// player.streams.playlist.listen((e) => print(e));
 /// player.streams.playing.listen((e) => print(e));
@@ -52,27 +56,33 @@ import 'package:media_kit/src/libmpv/player.dart' as libmpv;
 /// player.streams.audioDevice.listen((e) => print(e));
 /// player.streams.audioDevices.listen((e) => print(e));
 ///
-/// ...
+///
+/// // Open a playable [Media] or [Playlist].
 ///
 /// await player.open(Media('file:///C:/Users/Hitesh/Music/Sample.mp3'));
 /// await player.open(Media('file:///C:/Users/Hitesh/Video/Sample.mkv'));
+/// await player.open(Media('asset:///videos/bee.mp4'));
 /// await player.open(
 ///   Playlist(
 ///     [
 ///       Media('https://www.example.com/sample.mp4'),
 ///       Media('rtsp://www.example.com/live'),
 ///     ],
+///     // Select the starting index.
+///     index: 1,
 ///   ),
+///   // Select whether playback should start or not.
+///   play: false,
 /// );
 ///
-/// ...
+/// // Control playback state.
 ///
 /// await player.play();
 /// await player.pause();
 /// await player.playOrPause();
 /// await player.seek(const Duration(seconds: 10));
 ///
-/// ...
+/// // Use or modify the queue.
 ///
 /// await player.next();
 /// await player.previous();
@@ -80,7 +90,7 @@ import 'package:media_kit/src/libmpv/player.dart' as libmpv;
 /// await player.add(Media('https://www.example.com/sample.mp4'));
 /// await player.move(0, 2);
 ///
-/// ...
+/// // Customize speed, pitch, volume, shuffle, playlist mode, audio device.
 ///
 /// await player.setRate(1.0);
 /// await player.setPitch(1.2);
@@ -89,7 +99,7 @@ import 'package:media_kit/src/libmpv/player.dart' as libmpv;
 /// await player.setPlaylistMode(PlaylistMode.loop);
 /// await player.setAudioDevice(AudioDevice.auto());
 ///
-/// ...
+/// // Release allocated resources back to the system.
 ///
 /// await player.dispose();
 /// ```
@@ -116,12 +126,7 @@ class Player {
     if (Platform.isAndroid) {
       platform = libmpv.Player(configuration: configuration);
     }
-    if (platform == null) {
-      // TODO: Implement other platforms.
-      throw UnimplementedError(
-        'No [Player] implementation found for ${Platform.operatingSystem}.',
-      );
-    }
+    // TODO: Implement other platforms.
   }
 
   /// Platform specific internal implementation initialized depending upon the current platform.

--- a/media_kit/lib/src/player.dart
+++ b/media_kit/lib/src/player.dart
@@ -17,7 +17,7 @@ import 'package:media_kit/src/models/playlist_mode.dart';
 import 'package:media_kit/src/models/player_streams.dart';
 
 import 'package:media_kit/src/platform_player.dart';
-import 'package:media_kit/src/libmpv/player.dart' as libmpv;
+import 'package:media_kit/src/libmpv/player.dart' as _libmpv;
 
 /// {@template player}
 ///
@@ -112,19 +112,19 @@ class Player {
     PlayerConfiguration configuration = const PlayerConfiguration(),
   }) {
     if (Platform.isWindows) {
-      platform = libmpv.Player(configuration: configuration);
+      platform = _libmpv.Player(configuration: configuration);
     }
     if (Platform.isLinux) {
-      platform = libmpv.Player(configuration: configuration);
+      platform = _libmpv.Player(configuration: configuration);
     }
     if (Platform.isMacOS) {
-      platform = libmpv.Player(configuration: configuration);
+      platform = _libmpv.Player(configuration: configuration);
     }
     if (Platform.isIOS) {
-      platform = libmpv.Player(configuration: configuration);
+      platform = _libmpv.Player(configuration: configuration);
     }
     if (Platform.isAndroid) {
-      platform = libmpv.Player(configuration: configuration);
+      platform = _libmpv.Player(configuration: configuration);
     }
     // TODO: Implement other platforms.
   }

--- a/media_kit_native_event_loop/src/media_kit_native_event_loop.cc
+++ b/media_kit_native_event_loop/src/media_kit_native_event_loop.cc
@@ -13,6 +13,22 @@ MediaKitEventLoopHandler& MediaKitEventLoopHandler::GetInstance() {
   return instance;
 }
 
+void MediaKitEventLoopHandler::Initialize() {
+  std::lock_guard<std::mutex> l(mutex_);
+  if (mutexes_.size() > 0 && promises_.size() > 0) {
+    // Destroy already running |mpv_handle|(s).
+    std::cout << "media_kit: "
+              << "Destroying " << mutexes_.size() << " [Player] instances..."
+              << std::endl;
+    for (auto& [handle, _] : mutexes_) {
+      mpv_command_string(handle, "quit 0");
+    }
+    std::cout << "media_kit: Done." << std::endl;
+    mutexes_.clear();
+    promises_.clear();
+  }
+}
+
 void MediaKitEventLoopHandler::Register(int64_t handle,
                                         void* post_c_object,
                                         int64_t send_port) {
@@ -21,6 +37,7 @@ void MediaKitEventLoopHandler::Register(int64_t handle,
 
     for (;;) {
       {
+        std::lock_guard<std::mutex> l(mutex_);
         std::lock_guard<std::mutex> lock(mutexes_[context]);
         promises_[context] = std::promise<void>();
       }
@@ -46,6 +63,11 @@ void MediaKitEventLoopHandler::Register(int64_t handle,
       fn(send_port, &event_object);
 
       if (event->event_id == MPV_EVENT_SHUTDOWN) {
+        std::cout << "media_kit: " << reinterpret_cast<int64_t>(context) << " "
+                  << "MPV_EVENT_SHUTDOWN" << std::endl;
+        std::lock_guard<std::mutex> l(mutex_);
+        mutexes_.erase(context);
+        promises_.erase(context);
         break;
       }
 
@@ -58,6 +80,7 @@ void MediaKitEventLoopHandler::Register(int64_t handle,
 
 void MediaKitEventLoopHandler::Notify(int64_t handle) {
   auto context = reinterpret_cast<mpv_handle*>(handle);
+  std::lock_guard<std::mutex> l(mutex_);
   std::lock_guard<std::mutex> lock(mutexes_[context]);
   // Allow next |mpv_wait_event| to be called.
   promises_[context].set_value();
@@ -70,6 +93,10 @@ MediaKitEventLoopHandler::~MediaKitEventLoopHandler() {}
 // ---------------------------------------------------------------------------
 // C API for access using dart:ffi
 // ---------------------------------------------------------------------------
+
+void MediaKitEventLoopHandlerInitialize() {
+  MediaKitEventLoopHandler::GetInstance().Initialize();
+}
 
 void MediaKitEventLoopHandlerRegister(int64_t handle,
                                       void* post_c_object,

--- a/media_kit_native_event_loop/src/media_kit_native_event_loop.h
+++ b/media_kit_native_event_loop/src/media_kit_native_event_loop.h
@@ -23,12 +23,15 @@
 #include "dart_api_types.h"
 
 #include <future>
+#include <iostream>
 #include <functional>
 #include <unordered_map>
 
 class MediaKitEventLoopHandler {
  public:
   static MediaKitEventLoopHandler& GetInstance();
+
+  void Initialize();
 
   void Register(int64_t handle, void* post_c_object, int64_t send_port);
 
@@ -42,6 +45,8 @@ class MediaKitEventLoopHandler {
   MediaKitEventLoopHandler();
 
   ~MediaKitEventLoopHandler();
+
+  std::mutex mutex_;
 
   std::unordered_map<mpv_handle*, std::mutex> mutexes_;
   // std::promise(s) are working very well & look more readable. I'm tired of
@@ -63,6 +68,8 @@ class MediaKitEventLoopHandler {
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+DLLEXPORT void MediaKitEventLoopHandlerInitialize();
 
 DLLEXPORT void MediaKitEventLoopHandlerRegister(int64_t handle,
                                                 void* post_c_object,

--- a/media_kit_test/ios/Podfile.lock
+++ b/media_kit_test/ios/Podfile.lock
@@ -40,6 +40,9 @@ PODS:
     - Flutter
   - media_kit_video (0.0.1):
     - Flutter
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - SDWebImage (5.15.5):
     - SDWebImage/Core (= 5.15.5)
   - SDWebImage/Core (5.15.5)
@@ -51,6 +54,7 @@ DEPENDENCIES:
   - media_kit_libs_ios_video (from `.symlinks/plugins/media_kit_libs_ios_video/ios`)
   - media_kit_native_event_loop (from `.symlinks/plugins/media_kit_native_event_loop/ios`)
   - media_kit_video (from `.symlinks/plugins/media_kit_video/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/ios`)
 
 SPEC REPOS:
   trunk:
@@ -70,6 +74,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/media_kit_native_event_loop/ios"
   media_kit_video:
     :path: ".symlinks/plugins/media_kit_video/ios"
+  path_provider_foundation:
+    :path: ".symlinks/plugins/path_provider_foundation/ios"
 
 SPEC CHECKSUMS:
   DKImagePickerController: b512c28220a2b8ac7419f21c491fc8534b7601ac
@@ -79,6 +85,7 @@ SPEC CHECKSUMS:
   media_kit_libs_ios_video: 045418d93c495fb3eaa7b8263839d991c206fa14
   media_kit_native_event_loop: 9f9eb778d0d806ab9486eff7513f7f90f07d50f8
   media_kit_video: c6ae801433b484912087b519b45f1beac97b960b
+  path_provider_foundation: c68054786f1b4f3343858c1e1d0caaded73f0be9
   SDWebImage: fd7e1a22f00303e058058278639bf6196ee431fe
   SwiftyGif: 93a1cc87bf3a51916001cf8f3d63835fb64c819f
 

--- a/media_kit_test/lib/main.dart
+++ b/media_kit_test/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:media_kit/media_kit.dart';
 
 import 'tests/01.single_player_single_video.dart';
 import 'tests/02.single_player_multiple_video.dart';
@@ -12,6 +13,7 @@ import 'common/sources.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  MediaKit.ensureInitialized();
   runApp(const MyApp(DownloadingScreen()));
   await prepareSources();
   runApp(const MyApp(PrimaryScreen()));

--- a/media_kit_test/lib/tests/05.stress_test.dart
+++ b/media_kit_test/lib/tests/05.stress_test.dart
@@ -23,9 +23,7 @@ class _StressTestScreenState extends State<StressTestScreen> {
     Future.microtask(
       () async {
         for (int i = 0; i < count; i++) {
-          final player = Player(
-            configuration: const PlayerConfiguration(events: false),
-          );
+          final player = Player();
           final controller = await VideoController.create(player);
           players.add(player);
           controllers.add(controller);

--- a/media_kit_test/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/media_kit_test/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,8 +7,10 @@ import Foundation
 
 import media_kit_libs_macos_video
 import media_kit_video
+import path_provider_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   MediaKitLibsMacosVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitLibsMacosVideoPlugin"))
   MediaKitVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitVideoPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/media_kit_test/macos/Podfile.lock
+++ b/media_kit_test/macos/Podfile.lock
@@ -6,12 +6,16 @@ PODS:
     - FlutterMacOS
   - media_kit_video (0.0.1):
     - FlutterMacOS
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
   - media_kit_libs_macos_video (from `Flutter/ephemeral/.symlinks/plugins/media_kit_libs_macos_video/macos`)
   - media_kit_native_event_loop (from `Flutter/ephemeral/.symlinks/plugins/media_kit_native_event_loop/macos`)
   - media_kit_video (from `Flutter/ephemeral/.symlinks/plugins/media_kit_video/macos`)
+  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/macos`)
 
 EXTERNAL SOURCES:
   FlutterMacOS:
@@ -22,12 +26,15 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/media_kit_native_event_loop/macos
   media_kit_video:
     :path: Flutter/ephemeral/.symlinks/plugins/media_kit_video/macos
+  path_provider_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/macos
 
 SPEC CHECKSUMS:
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   media_kit_libs_macos_video: d8f5b02cc1ab6f26dc3880e8367fd8ccaea73751
   media_kit_native_event_loop: 9a1b256cfb11adcaebd13a2969c617720c3187e0
   media_kit_video: 007acd0fce8002e6c8cd0b97a1daaf45b1aaba55
+  path_provider_foundation: c68054786f1b4f3343858c1e1d0caaded73f0be9
 
 PODFILE CHECKSUM: 8d40c19d3cbdb380d870685c3a564c989f1efa52
 

--- a/media_kit_test/windows/flutter/generated_plugin_registrant.cc
+++ b/media_kit_test/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <media_kit_libs_windows_video/media_kit_libs_windows_video_plugin_c_api.h>
 #include <media_kit_video/media_kit_video_plugin_c_api.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  MediaKitLibsWindowsVideoPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("MediaKitLibsWindowsVideoPluginCApi"));
   MediaKitVideoPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("MediaKitVideoPluginCApi"));
 }

--- a/media_kit_test/windows/flutter/generated_plugins.cmake
+++ b/media_kit_test/windows/flutter/generated_plugins.cmake
@@ -3,11 +3,11 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  media_kit_libs_windows_video
   media_kit_video
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
-  media_kit_libs_windows_video
   media_kit_native_event_loop
 )
 

--- a/media_kit_video/common/darwin/Classes/plugin/TextureSW.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/TextureSW.swift
@@ -44,6 +44,7 @@ public class TextureSW: NSObject, FlutterTexture, ResizableTextureProtocol {
   }
 
   private func initMPV() {
+    MPVHelpers.checkError(mpv_set_option_string(handle, "vo", "libmpv"))
     MPVHelpers.checkError(mpv_set_option_string(handle, "hwdec", "auto"))
 
     let api = UnsafeMutableRawPointer(

--- a/media_kit_video/ios/Classes/plugin/TextureHW.swift
+++ b/media_kit_video/ios/Classes/plugin/TextureHW.swift
@@ -56,6 +56,7 @@ public class TextureHW: NSObject, FlutterTexture, ResizableTextureProtocol {
       EAGLContext.setCurrent(nil)
     }
 
+    MPVHelpers.checkError(mpv_set_option_string(handle, "vo", "libmpv"))
     MPVHelpers.checkError(mpv_set_option_string(handle, "hwdec", "auto"))
 
     let api = UnsafeMutableRawPointer(

--- a/media_kit_video/lib/src/video_controller_android.dart
+++ b/media_kit_video/lib/src/video_controller_android.dart
@@ -97,7 +97,8 @@ class VideoControllerAndroid extends VideoController {
 
     // ----------------------------------------------
     // https://mpv.io/manual/stable/#video-output-drivers-mediacodec-embed
-    final mpv = MPV(NativeLibrary.find());
+    NativeLibrary.ensureInitialized();
+    final mpv = MPV(DynamicLibrary.open(NativeLibrary.path));
     final values = {
       'opengl-es': 'yes',
       'force-window': 'yes',
@@ -152,7 +153,8 @@ class VideoControllerAndroid extends VideoController {
     this.width = width;
     this.height = height;
     // ----------------------------------------------
-    final mpv = MPV(NativeLibrary.find());
+    NativeLibrary.ensureInitialized();
+    final mpv = MPV(DynamicLibrary.open(NativeLibrary.path));
     final name = 'android-surface-size'.toNativeUtf8();
     final value = '${width}x$height'.toNativeUtf8();
     mpv.mpv_set_option_string(

--- a/media_kit_video/linux/video_output.cc
+++ b/media_kit_video/linux/video_output.cc
@@ -92,6 +92,7 @@ VideoOutput* video_output_new(FlTextureRegistrar* texture_registrar,
   self->width = width;
   self->height = height;
   self->enable_hardware_acceleration = enable_hardware_acceleration;
+  mpv_set_option_string(self->handle, "vo", "libmpv");
   mpv_set_option_string(self->handle, "video-sync", "audio");
   mpv_set_option_string(self->handle, "video-timing-offset", "0");
   gboolean hardware_acceleration_supported = FALSE;

--- a/media_kit_video/macos/Classes/plugin/TextureHW.swift
+++ b/media_kit_video/macos/Classes/plugin/TextureHW.swift
@@ -60,6 +60,7 @@ public class TextureHW: NSObject, FlutterTexture, ResizableTextureProtocol {
       CGLSetCurrentContext(nil)
     }
 
+    MPVHelpers.checkError(mpv_set_option_string(handle, "vo", "libmpv"))
     MPVHelpers.checkError(mpv_set_option_string(handle, "hwdec", "auto"))
 
     let api = UnsafeMutableRawPointer(

--- a/media_kit_video/windows/video_output.cc
+++ b/media_kit_video/windows/video_output.cc
@@ -40,13 +40,14 @@ VideoOutput::VideoOutput(int64_t handle,
   // the existing |Render| or |Resize| calls from another |VideoOutput|
   // instances (which will result in access violation).
   auto future = thread_pool_ref_->Post([&]() {
+    mpv_set_option_string(handle_, "vo", "libmpv");
+    mpv_set_option_string(handle_, "video-sync", "audio");
+    mpv_set_option_string(handle_, "video-timing-offset", "0");
     // First try to initialize video playback with hardware acceleration &
     // |ANGLESurfaceManager|, use S/W API as fallback.
     auto is_hardware_acceleration_enabled = false;
     // Attempt to use H/W rendering.
     try {
-      mpv_set_option_string(handle_, "video-sync", "audio");
-      mpv_set_option_string(handle_, "video-timing-offset", "0");
       // OpenGL context needs to be set before |mpv_render_context_create|.
       surface_manager_ = std::make_unique<ANGLESurfaceManager>(
           static_cast<int32_t>(width_.value_or(1)),


### PR DESCRIPTION
Adds new API `MediaKit.ensureInitialized`, this allows to:
- Handle libmpv & package:media_kit_native_event_loop discovery + loading in advance.
- Receive some additional initialization arguments etc.
- Expose ability to handle/catch any initialization errors to clients e.g. libmpv shared library not found etc.
- Dispose already running `Player` instances on hot-restart.

Other changes:
- Set `PlayerConfiguration.vo` to `null` by default.
  Windows, GNU/Linux & Android embeddings now set it to `libmpv` when a new `VideoOutput` is created.
- Refactor libmpv `mpv_handle*` initialization into `InitializerIsolate` & `InitializerNativeEventLoop` classes.