### PR TITLE
fix HTTPS m3u8 file not loading

### DIFF
--- a/media_kit/lib/src/libmpv/player.dart
+++ b/media_kit/lib/src/libmpv/player.dart
@@ -1190,6 +1190,19 @@ class Player extends PlatformPlayer {
         calloc.free(value);
       }
     }
+    {
+      final whitelist = configuration.protocolWhitelist.join(',');
+      final name = "demuxer-lavf-o".toNativeUtf8();
+      final data = "protocol_whitelist=[$whitelist]".toNativeUtf8();
+      _libmpv?.mpv_set_property_string(
+        result,
+        name.cast(),
+        data.cast(),
+      );
+      calloc.free(name);
+      calloc.free(data);
+    }
+
     // TODO(@alexmercerind):
     // This causes `MPV_EVENT_END_FILE` to not fire for last playlist item.
     // Ideally, we want to keep the last video frame visible.

--- a/media_kit/lib/src/libmpv/player.dart
+++ b/media_kit/lib/src/libmpv/player.dart
@@ -1192,8 +1192,8 @@ class Player extends PlatformPlayer {
     }
     {
       final whitelist = configuration.protocolWhitelist.join(',');
-      final name = "demuxer-lavf-o".toNativeUtf8();
-      final data = "protocol_whitelist=[$whitelist]".toNativeUtf8();
+      final name = 'demuxer-lavf-o'.toNativeUtf8();
+      final data = 'protocol_whitelist=[$whitelist]'.toNativeUtf8();
       _libmpv?.mpv_set_property_string(
         result,
         name.cast(),

--- a/media_kit/lib/src/platform_player.dart
+++ b/media_kit/lib/src/platform_player.dart
@@ -98,6 +98,13 @@ class PlayerConfiguration {
   /// Default: `32` MB or `32 * 1024 * 1024` bytes.
   final int bufferSize;
 
+  /// Sets the list of allowed protocols for libmpv backend.
+  ///
+  /// Default: `["file", "tcp", "tls", "http", "https", "crypto","data"]`.
+  /// 
+  /// FFmpeg [docs](https://ffmpeg.org/ffmpeg-protocols.html#Protocol-Options)
+  final List<String> protocolWhitelist;
+
   /// Optional callback invoked when the internals of the [Player] are initialized & ready for playback.
   ///
   /// Default: `null`.
@@ -113,6 +120,15 @@ class PlayerConfiguration {
     this.title,
     this.bufferSize = 32 * 1024 * 1024,
     this.ready,
+    this.protocolWhitelist = const [
+      "file",
+      "tcp",
+      "tls",
+      "http",
+      "https",
+      "crypto",
+      "data",
+    ],
   });
 }
 

--- a/media_kit/lib/src/platform_player.dart
+++ b/media_kit/lib/src/platform_player.dart
@@ -65,14 +65,17 @@ class PlayerConfiguration {
   final MPVLogLevel logLevel;
 
   /// Enables on-screen controls for libmpv backend.
+  ///
   /// Default: `false`.
   final bool osc;
 
   /// Enables or disables video output for libmpv backend.
+  ///
   /// Default: `null`.
   final bool? vid;
 
   /// Sets the video output driver for libmpv backend.
+  ///
   /// Default: `null`.
   final String? vo;
 
@@ -100,9 +103,9 @@ class PlayerConfiguration {
 
   /// Sets the list of allowed protocols for libmpv backend.
   ///
-  /// Default: `["file", "tcp", "tls", "http", "https", "crypto","data"]`.
-  /// 
-  /// FFmpeg [docs](https://ffmpeg.org/ffmpeg-protocols.html#Protocol-Options)
+  /// Default: `['file', 'tcp', 'tls', 'http', 'https', 'crypto', 'data']`.
+  ///
+  /// Learn more: https://ffmpeg.org/ffmpeg-protocols.html#Protocol-Options
   final List<String> protocolWhitelist;
 
   /// Optional callback invoked when the internals of the [Player] are initialized & ready for playback.
@@ -121,13 +124,13 @@ class PlayerConfiguration {
     this.bufferSize = 32 * 1024 * 1024,
     this.ready,
     this.protocolWhitelist = const [
-      "file",
-      "tcp",
-      "tls",
-      "http",
-      "https",
-      "crypto",
-      "data",
+      'file',
+      'tcp',
+      'tls',
+      'http',
+      'https',
+      'crypto',
+      'data',
     ],
   });
 }


### PR DESCRIPTION
Added a configuration setting to the player to set [demuxer-lavf-o](https://mpv.io/manual/stable/#options-demuxer-lavf-o) with the value `protocol_whitelist=[file,tcp,tls,http,https]` this property allows the library to parse M3U8 files with the specified protocols, which should resolve issues with playing HTTPS M3U8 files.

### Dart example with using  `protocolWhitelist`
```dart
final Player player = Player(
  configuration: const PlayerConfiguration(
    logLevel: MPVLogLevel.warn,
    protocolWhitelist: ["file", "tcp", "tls", "http", "https", "crypto","data"],
  ),
)
```
### Test File from [omagestream](https://www.omegastream.net/Home) service

```m3u8
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-INDEPENDENT-SEGMENTS

#EXT-X-STREAM-INF:BANDWIDTH=674554,CODECS="avc1.640015,mp4a.40.2",RESOLUTION=426x240,FRAME-RATE=30,AUDIO="audio2"
https://api.omegastream.net/stream/company/processed-enterprise-media/bd413f82/video/57721636-0247-4588-8772-b2ec036504e0/playlist_1.m3u8?s=58c953dcbcfda4dd29e9cafa2c0a38a21964fef7

#EXT-X-STREAM-INF:BANDWIDTH=994337,CODECS="avc1.64001E,mp4a.40.2",RESOLUTION=640x360,FRAME-RATE=30,AUDIO="audio2"
https://api.omegastream.net/stream/company/processed-enterprise-media/bd413f82/video/57721636-0247-4588-8772-b2ec036504e0/playlist_2.m3u8?s=58c953dcbcfda4dd29e9cafa2c0a38a21964fef7

#EXT-X-STREAM-INF:BANDWIDTH=1518890,CODECS="avc1.64001F,mp4a.40.2",RESOLUTION=854x480,FRAME-RATE=30,AUDIO="audio2"
https://api.omegastream.net/stream/company/processed-enterprise-media/bd413f82/video/57721636-0247-4588-8772-b2ec036504e0/playlist_3.m3u8?s=58c953dcbcfda4dd29e9cafa2c0a38a21964fef7

#EXT-X-STREAM-INF:BANDWIDTH=2666804,CODECS="avc1.64001F,mp4a.40.2",RESOLUTION=1280x720,FRAME-RATE=30,AUDIO="audio2"
https://api.omegastream.net/stream/company/processed-enterprise-media/bd413f82/video/57721636-0247-4588-8772-b2ec036504e0/playlist_4.m3u8?s=58c953dcbcfda4dd29e9cafa2c0a38a21964fef7

#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="audio2",NAME="5",AUTOSELECT=YES,URI="https://api.omegastream.net/stream/company/processed-enterprise-media/bd413f82/video/57721636-0247-4588-8772-b2ec036504e0/playlist_5.m3u8?s=58c953dcbcfda4dd29e9cafa2c0a38a21964fef7",CHANNELS="2"
```

### Example using MPV command line tool
```sh
mpv --demuxer-lavf-o="protocol_whitelist=[file,tcp,tls,http,https]" example.m3u8
```

Credits: @zezo357 helped alot ♥️