### PR TITLE
fix(windows): synchronize texture object deletion in on unregister

### DIFF
--- a/media_kit_video/CHANGELOG.md
+++ b/media_kit_video/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.6
+
+- fix(windows): synchronize texture object deletion in on unregister _v.i.z_ `VideoOutput::Resize` or `VideoOutput::~VideoOutput`
+
 ## 0.0.5
 
 - Android support

--- a/media_kit_video/pubspec.yaml
+++ b/media_kit_video/pubspec.yaml
@@ -2,7 +2,7 @@ name: media_kit_video
 description: Native implementation for video playback in package:media_kit.
 homepage: https://github.com/alexmercerind/media_kit
 repository: https://github.com/alexmercerind/media_kit
-version: 0.0.5
+version: 0.0.6
 funding:
   - https://www.github.com/sponsors/alexmercerind
 

--- a/media_kit_video/windows/video_output.h
+++ b/media_kit_video/windows/video_output.h
@@ -86,6 +86,8 @@ class VideoOutput {
   ThreadPool* thread_pool_ref_ = nullptr;
   bool destroyed_ = false;
 
+  std::mutex textures_mutex_ = std::mutex();
+
   std::unordered_map<int64_t, std::unique_ptr<flutter::TextureVariant>>
       texture_variants_ = {};
 


### PR DESCRIPTION
fix(windows): synchronize texture object deletion in on unregister _v.i.z_ `VideoOutput::Resize` or `VideoOutput::~VideoOutput`