### PR TITLE
fix: escape ':' in url passed to property 'audio-files'

### DIFF
--- a/media_kit_test/lib/common/widgets.dart
+++ b/media_kit_test/lib/common/widgets.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'package:flutter/material.dart';
 
 import 'package:media_kit/media_kit.dart';
@@ -315,10 +316,17 @@ Future<void> showURIPicker(BuildContext context, Player player) async {
                 child: ElevatedButton(
                   onPressed: () {
                     if (key.currentState!.validate()) {
+                      String audioUrl = audio.text;
+                      if (Platform.isLinux ||
+                          Platform.isAndroid ||
+                          Platform.isMacOS) {
+                        // mpv use ':' as a list separator. we need to escape it to avoid problem with url
+                        audioUrl = audioUrl.replaceAll(':', '\\:');
+                      }
                       if (player.platform is libmpvPlayer) {
                         (player.platform as libmpvPlayer).setProperty(
                           "audio-files",
-                          audio.text,
+                          audioUrl,
                         );
                       }
                       player.open(Media(video.text));


### PR DESCRIPTION
mpv lists on unix use ':' as separator which breaks using url with property like 'audio-files'

Look at https://mpv.io/manual/stable/#list-options for the details

Being personnaly bitten by this at least twice, I could recommend to let it be more visible, at least in the example/test code of media_kit_test. 🤞

If media_kit_test is the app used where to direct users to test urls and such...