### PR TITLE
fix/refactor: improve player lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,41 @@ name: Github Actions
 on: [push, pull_request]
 
 jobs:
-  media_kit-tests:
-    name: package:media_kit tests
+  media_kit-tests-windows:
+    name: package:media_kit tests (Windows)
+    runs-on: windows-latest
+    defaults:
+      run:
+        working-directory: media_kit
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: "true"
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: "stable"
+      - run: dart pub get
+      - run: dart test
+
+  media_kit-tests-linux:
+    name: package:media_kit tests (Linux)
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: media_kit
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: "true"
+      - uses: subosito/flutter-action@v1
+        with:
+          channel: "stable"
+      - run: dart pub get
+      - run: dart test
+
+  media_kit-tests-macos:
+    name: package:media_kit tests (macOS)
+    runs-on: macos-latest
     defaults:
       run:
         working-directory: media_kit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,21 +2,23 @@ name: Github Actions
 on: [push, pull_request]
 
 jobs:
-  media_kit-tests-windows:
-    name: package:media_kit tests (Windows)
-    runs-on: windows-latest
-    defaults:
-      run:
-        working-directory: media_kit
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: "true"
-      - uses: subosito/flutter-action@v1
-        with:
-          channel: "stable"
-      - run: dart pub get
-      - run: dart test
+  # TODO: Enable package:media_kit tests on Windows
+
+  # media_kit-tests-windows:
+  #   name: package:media_kit tests (Windows)
+  #   runs-on: windows-latest
+  #   defaults:
+  #     run:
+  #       working-directory: media_kit
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         submodules: "true"
+  #     - uses: subosito/flutter-action@v1
+  #       with:
+  #         channel: "stable"
+  #     - run: dart pub get
+  #     - run: dart test
 
   media_kit-tests-linux:
     name: package:media_kit tests (Linux)
@@ -28,27 +30,31 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: "true"
+      - run: sudo apt-get update
+      - run: sudo apt-get install clang cmake ninja-build pkg-config libgtk-3-dev mpv libmpv-dev dpkg-dev p7zip-full p7zip-rar
       - uses: subosito/flutter-action@v1
         with:
           channel: "stable"
       - run: dart pub get
       - run: dart test
 
-  media_kit-tests-macos:
-    name: package:media_kit tests (macOS)
-    runs-on: macos-latest
-    defaults:
-      run:
-        working-directory: media_kit
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: "true"
-      - uses: subosito/flutter-action@v1
-        with:
-          channel: "stable"
-      - run: dart pub get
-      - run: dart test
+  # TODO: Enable package:media_kit tests on macOS
+
+  # media_kit-tests-macos:
+  #   name: package:media_kit tests (macOS)
+  #   runs-on: macos-latest
+  #   defaults:
+  #     run:
+  #       working-directory: media_kit
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         submodules: "true"
+  #     - uses: subosito/flutter-action@v1
+  #       with:
+  #         channel: "stable"
+  #     - run: dart pub get
+  #     - run: dart test
 
   windows:
     name: Windows

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ dependencies:
   
   media_kit_native_event_loop: ^1.0.3            # Support for higher number of concurrent instances & better performance.
   
-  media_kit_libs_windows_video: ^1.0.2           # Windows package for video native libraries.
   media_kit_libs_android_video: ^1.0.0           # Android package for video native libraries.
-  media_kit_libs_macos_video: ^1.0.4             # macOS package for video native libraries.
   media_kit_libs_ios_video: ^1.0.4               # iOS package for video native libraries.
+  media_kit_libs_macos_video: ^1.0.4             # macOS package for video native libraries.
+  media_kit_libs_windows_video: ^1.0.2           # Windows package for video native libraries.
   media_kit_libs_linux: ^1.0.2                   # GNU/Linux dependency package.
 ```
 
@@ -67,10 +67,10 @@ dependencies:
   
   media_kit_native_event_loop: ^1.0.2            # Support for higher number of concurrent instances & better performance.
   
-  media_kit_libs_windows_audio: ^1.0.3           # Windows package for audio native libraries.
   media_kit_libs_android_audio: ^1.0.0           # Android package for audio native libraries.
-  media_kit_libs_macos_audio: ^1.0.4             # macOS package for audio native libraries.
   media_kit_libs_ios_audio: ^1.0.4               # iOS package for audio native libraries.
+  media_kit_libs_macos_audio: ^1.0.4             # macOS package for audio native libraries.
+  media_kit_libs_windows_audio: ^1.0.3           # Windows package for audio native libraries.
   media_kit_libs_linux: ^1.0.2                   # GNU/Linux dependency package.
 ```
 
@@ -148,6 +148,7 @@ import 'package:media_kit/media_kit.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  /// [MediaKit.ensureInitialized] must be called before using the library.
   MediaKit.ensureInitialized();
   runApp(const MyApp());
 }

--- a/README.md
+++ b/README.md
@@ -231,10 +231,20 @@ import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';                        /// Provides [Player], [Media], [Playlist] etc.
 import 'package:media_kit_video/media_kit_video.dart';            /// Provides [VideoController] & [Video] etc.
 
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  MediaKit.ensureInitialized();
+  runApp(
+    const MaterialApp(
+      home: MyScreen()
+    ),
+  );
+}
+
 class MyScreen extends StatefulWidget {
   const MyScreen({Key? key}) : super(key: key);
   @override
-  State<MyScreen> createState() => _MyScreenState();
+  State<MyScreen> createState() => MyScreenState();
 }
 
 class MyScreenState extends State<MyScreen> {

--- a/media_kit/README.md
+++ b/media_kit/README.md
@@ -223,10 +223,20 @@ import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';                        /// Provides [Player], [Media], [Playlist] etc.
 import 'package:media_kit_video/media_kit_video.dart';            /// Provides [VideoController] & [Video] etc.
 
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  MediaKit.ensureInitialized();
+  runApp(
+    const MaterialApp(
+      home: MyScreen()
+    ),
+  );
+}
+
 class MyScreen extends StatefulWidget {
   const MyScreen({Key? key}) : super(key: key);
   @override
-  State<MyScreen> createState() => _MyScreenState();
+  State<MyScreen> createState() => MyScreenState();
 }
 
 class MyScreenState extends State<MyScreen> {

--- a/media_kit/README.md
+++ b/media_kit/README.md
@@ -44,10 +44,10 @@ dependencies:
   
   media_kit_native_event_loop: ^1.0.3            # Support for higher number of concurrent instances & better performance.
   
-  media_kit_libs_windows_video: ^1.0.2           # Windows package for video native libraries.
   media_kit_libs_android_video: ^1.0.0           # Android package for video native libraries.
-  media_kit_libs_macos_video: ^1.0.4             # macOS package for video native libraries.
   media_kit_libs_ios_video: ^1.0.4               # iOS package for video native libraries.
+  media_kit_libs_macos_video: ^1.0.4             # macOS package for video native libraries.
+  media_kit_libs_windows_video: ^1.0.2           # Windows package for video native libraries.
   media_kit_libs_linux: ^1.0.2                   # GNU/Linux dependency package.
 ```
 
@@ -59,10 +59,10 @@ dependencies:
   
   media_kit_native_event_loop: ^1.0.2            # Support for higher number of concurrent instances & better performance.
   
-  media_kit_libs_windows_audio: ^1.0.3           # Windows package for audio native libraries.
   media_kit_libs_android_audio: ^1.0.0           # Android package for audio native libraries.
-  media_kit_libs_macos_audio: ^1.0.4             # macOS package for audio native libraries.
   media_kit_libs_ios_audio: ^1.0.4               # iOS package for audio native libraries.
+  media_kit_libs_macos_audio: ^1.0.4             # macOS package for audio native libraries.
+  media_kit_libs_windows_audio: ^1.0.3           # Windows package for audio native libraries.
   media_kit_libs_linux: ^1.0.2                   # GNU/Linux dependency package.
 ```
 
@@ -140,6 +140,7 @@ import 'package:media_kit/media_kit.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  /// [MediaKit.ensureInitialized] must be called before using the library.
   MediaKit.ensureInitialized();
   runApp(const MyApp());
 }

--- a/media_kit/example/README.md
+++ b/media_kit/example/README.md
@@ -89,10 +89,20 @@ import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';                        /// Provides [Player], [Media], [Playlist] etc.
 import 'package:media_kit_video/media_kit_video.dart';            /// Provides [VideoController] & [Video] etc.
 
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  MediaKit.ensureInitialized();
+  runApp(
+    const MaterialApp(
+      home: MyScreen()
+    ),
+  );
+}
+
 class MyScreen extends StatefulWidget {
   const MyScreen({Key? key}) : super(key: key);
   @override
-  State<MyScreen> createState() => _MyScreenState();
+  State<MyScreen> createState() => MyScreenState();
 }
 
 class MyScreenState extends State<MyScreen> {

--- a/media_kit/example/README.md
+++ b/media_kit/example/README.md
@@ -6,6 +6,7 @@ import 'package:media_kit/media_kit.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  /// [MediaKit.ensureInitialized] must be called before using the library.
   MediaKit.ensureInitialized();
   runApp(const MyApp());
 }

--- a/media_kit/lib/src/libmpv/core/fallback_bitrate_handler.dart
+++ b/media_kit/lib/src/libmpv/core/fallback_bitrate_handler.dart
@@ -15,10 +15,9 @@ import 'package:safe_local_storage/safe_local_storage.dart';
 /// Considering FLAC is a lossless format, this approximation should be fine.
 /// At-least better than the one in libmpv, because it calculates the bitrate from the loaded stream currently in-memory & updates it dynamically as playback progresses.
 abstract class FallbackBitrateHandler {
-  static bool isLocalFLACOrOGGFile(String uri) =>
-      extractLocalFLACorOGGFilePath(uri) != null;
+  static bool supported(String uri) => extractFilePath(uri) != null;
 
-  static String? extractLocalFLACorOGGFilePath(String uri) {
+  static String? extractFilePath(String uri) {
     try {
       // Handle local [File] paths.
       final parser = URIParser(uri);
@@ -43,7 +42,7 @@ abstract class FallbackBitrateHandler {
 
   static Future<double> calculateBitrate(String uri, Duration duration) async {
     try {
-      final resource = extractLocalFLACorOGGFilePath(uri);
+      final resource = extractFilePath(uri);
       if (resource != null) {
         final file = File(resource);
         final size = await file.length_();

--- a/media_kit/lib/src/libmpv/core/fallback_bitrate_handler.dart
+++ b/media_kit/lib/src/libmpv/core/fallback_bitrate_handler.dart
@@ -11,8 +11,7 @@ import 'package:safe_local_storage/safe_local_storage.dart';
 /// libmpv doesn't seem to read the bitrate from the files which contain bitrate in their stream metadata (not file metadata).
 /// Typically, I've seen this happening with FLAC & OGG files, since they do not offer the bitrate as a metadata / attached-tags key.
 ///
-/// Adding this helper class to calculate the bitrate of the FLAC & OGG files manually.
-/// Considering FLAC is a lossless format, this approximation should be fine.
+/// Adding this helper class to calculate the bitrate of the FLAC & OGG files manually. Considering FLAC is a lossless format, this approximation should be fine.
 /// At-least better than the one in libmpv, because it calculates the bitrate from the loaded stream currently in-memory & updates it dynamically as playback progresses.
 abstract class FallbackBitrateHandler {
   static bool supported(String uri) => extractFilePath(uri) != null;

--- a/media_kit/lib/src/libmpv/player.dart
+++ b/media_kit/lib/src/libmpv/player.dart
@@ -71,7 +71,6 @@ class Player extends PlatformPlayer {
   ///       Media('rtsp://www.example.com/live'),
   ///     ],
   ///   ),
-  ///   play: true,
   /// );
   /// ```
   ///
@@ -79,7 +78,6 @@ class Player extends PlatformPlayer {
   Future<void> open(
     Playable playable, {
     bool play = true,
-    bool evictExtrasCache = true,
   }) async {
     final ctx = await _handle.future;
 
@@ -92,21 +90,7 @@ class Player extends PlatformPlayer {
       index = playable.index;
       playlist.addAll(playable.medias);
     } else {
-      throw ArgumentError.value(
-        playable,
-        'playable',
-        'Must be of type [Media] or [Playlist].',
-      );
-    }
-
-    if (evictExtrasCache) {
-      // Clean-up previous extras cache.
-      medias.clear();
-      bitrates.clear();
-      // Restore extras in currently added playlist.
-      for (final media in playlist) {
-        medias[media.uri] = media;
-      }
+      index = -1;
     }
 
     // Clean-up existing playlist & change currently playing libmpv index to none.
@@ -141,13 +125,6 @@ class Player extends PlatformPlayer {
           if (index > 0 && i != index) 'append',
         ],
       );
-    }
-
-    // Update the [PlayerState] & feed the event [Stream].
-    final object = Playlist(playlist, index: index);
-    state = state.copyWith(playlist: object);
-    if (!playlistController.isClosed) {
-      playlistController.add(object);
     }
 
     if (play) {
@@ -248,10 +225,6 @@ class Player extends PlatformPlayer {
         null,
       ],
     );
-    state.playlist.medias.add(media);
-    if (!playlistController.isClosed) {
-      playlistController.add(state.playlist);
-    }
   }
 
   /// Removes the [Media] at specified index from the [Player]'s playlist.
@@ -263,10 +236,6 @@ class Player extends PlatformPlayer {
         index.toString(),
       ],
     );
-    state.playlist.medias.removeAt(index);
-    if (!playlistController.isClosed) {
-      playlistController.add(state.playlist);
-    }
   }
 
   /// Jumps to next [Media] in the [Player]'s playlist.
@@ -322,8 +291,6 @@ class Player extends PlatformPlayer {
         to.toString(),
       ],
     );
-    state.playlist.medias.insert(to, state.playlist.medias.removeAt(from));
-    playlistController.add(state.playlist);
   }
 
   /// Seeks the currently playing [Media] in the [Player] by specified [Duration].
@@ -540,69 +507,11 @@ class Player extends PlatformPlayer {
   /// Enables or disables shuffle for [Player]. Default is `false`.
   @override
   Future<void> setShuffle(bool shuffle) async {
-    final ctx = await _handle.future;
     await _command(
       [
         shuffle ? 'playlist-shuffle' : 'playlist-unshuffle',
       ],
     );
-    final name = 'playlist'.toNativeUtf8();
-    final data = calloc<generated.mpv_node>();
-    _libmpv?.mpv_get_property(
-      ctx,
-      name.cast(),
-      generated.mpv_format.MPV_FORMAT_NODE,
-      data.cast(),
-    );
-    try {
-      // Shuffling updates the order of [state.playlist]. Fetching latest playlist from mpv & updating Dart stream.
-      if (data.ref.format == generated.mpv_format.MPV_FORMAT_NODE_ARRAY) {
-        final playlist = <Media>[];
-        for (int i = 0; i < data.ref.u.list.ref.num; i++) {
-          if (data.ref.u.list.ref.values[i].format ==
-              generated.mpv_format.MPV_FORMAT_NODE_MAP) {
-            for (int j = 0;
-                j < data.ref.u.list.ref.values[i].u.list.ref.num;
-                j++) {
-              if (data.ref.u.list.ref.values[i].u.list.ref.values[j].format ==
-                  generated.mpv_format.MPV_FORMAT_STRING) {
-                final property = data
-                    .ref.u.list.ref.values[i].u.list.ref.keys[j]
-                    .cast<Utf8>()
-                    .toDartString();
-                if (property == 'filename') {
-                  final value = data
-                      .ref.u.list.ref.values[i].u.list.ref.values[j].u.string
-                      .cast<Utf8>()
-                      .toDartString();
-                  playlist.add(medias[value]!);
-                }
-              }
-            }
-          }
-        }
-        state = state.copyWith(
-          playlist: state.playlist.copyWith(
-            medias: playlist,
-          ),
-        );
-        if (!playlistController.isClosed) {
-          playlistController.add(state.playlist);
-        }
-        // Free the memory allocated by `mpv_get_property`.
-        _libmpv?.mpv_free_node_contents(data);
-        calloc.free(name);
-        calloc.free(data);
-      }
-    } catch (exception, stacktrace) {
-      print(exception);
-      print(stacktrace);
-      await _command(
-        [
-          'playlist-unshuffle',
-        ],
-      );
-    }
   }
 
   /// Sets the current [AudioDevice] for audio output.
@@ -737,12 +646,20 @@ class Player extends PlatformPlayer {
         state = state.copyWith(
           playing: true,
           completed: false,
+          audioBitrate: null,
+          audioParams: const AudioParams(),
         );
         if (!playingController.isClosed) {
           playingController.add(true);
         }
         if (!completedController.isClosed) {
           completedController.add(false);
+        }
+        if (!audioBitrateController.isClosed) {
+          audioBitrateController.add(null);
+        }
+        if (!audioParamsController.isClosed) {
+          audioParamsController.add(const AudioParams());
         }
       }
     }
@@ -754,20 +671,12 @@ class Player extends PlatformPlayer {
           state = state.copyWith(
             playing: false,
             completed: true,
-            audioBitrate: null,
-            audioParams: const AudioParams(),
           );
           if (!playingController.isClosed) {
             playingController.add(false);
           }
           if (!completedController.isClosed) {
             completedController.add(true);
-          }
-          if (!audioBitrateController.isClosed) {
-            audioBitrateController.add(null);
-          }
-          if (!audioParamsController.isClosed) {
-            audioParamsController.add(const AudioParams());
           }
         }
       }
@@ -842,16 +751,51 @@ class Player extends PlatformPlayer {
           }
         }
       }
-      if (prop.ref.name.cast<Utf8>().toDartString() == 'playlist-pos' &&
-          prop.ref.format == generated.mpv_format.MPV_FORMAT_INT64) {
-        final index = prop.ref.data.cast<Int64>().value;
+      if (prop.ref.name.cast<Utf8>().toDartString() == 'playlist' &&
+          prop.ref.format == generated.mpv_format.MPV_FORMAT_NODE) {
+        final data = prop.ref.data.cast<generated.mpv_node>();
+        final list = data.ref.u.list.ref;
+        int index = -1;
+        List<Media> playlist = [];
+        for (int i = 0; i < list.num; i++) {
+          if (list.values[i].format ==
+              generated.mpv_format.MPV_FORMAT_NODE_MAP) {
+            final map = list.values[i].u.list.ref;
+            for (int j = 0; j < map.num; j++) {
+              final property = map.keys[j].cast<Utf8>().toDartString();
+              if (map.values[j].format ==
+                  generated.mpv_format.MPV_FORMAT_FLAG) {
+                if (property == 'playing') {
+                  final value = map.values[j].u.flag;
+                  if (value == 1) {
+                    index = i;
+                  }
+                }
+              }
+              if (map.values[j].format ==
+                  generated.mpv_format.MPV_FORMAT_STRING) {
+                if (property == 'filename') {
+                  final value =
+                      map.values[j].u.string.cast<Utf8>().toDartString();
+                  playlist.add(medias[value] ?? Media(value));
+                }
+              }
+            }
+          }
+        }
         state = state.copyWith(
-          playlist: state.playlist.copyWith(
+          playlist: Playlist(
+            playlist,
             index: index,
           ),
         );
         if (!playlistController.isClosed) {
-          playlistController.add(state.playlist);
+          playlistController.add(
+            Playlist(
+              playlist,
+              index: index,
+            ),
+          );
         }
       }
       if (prop.ref.name.cast<Utf8>().toDartString() == 'volume' &&
@@ -865,40 +809,38 @@ class Player extends PlatformPlayer {
       if (prop.ref.name.cast<Utf8>().toDartString() == 'audio-params' &&
           prop.ref.format == generated.mpv_format.MPV_FORMAT_NODE) {
         final data = prop.ref.data.cast<generated.mpv_node>();
+        final list = data.ref.u.list.ref;
         final params = <String, dynamic>{};
-        for (int i = 0; i < data.ref.u.list.ref.num; i++) {
-          final key = data.ref.u.list.ref.keys[i].cast<Utf8>().toDartString();
+        for (int i = 0; i < list.num; i++) {
+          final key = list.keys[i].cast<Utf8>().toDartString();
 
           switch (key) {
             case 'format':
               {
-                params[key] = data.ref.u.list.ref.values[i].u.string
-                    .cast<Utf8>()
-                    .toDartString();
+                params[key] =
+                    list.values[i].u.string.cast<Utf8>().toDartString();
                 break;
               }
             case 'samplerate':
               {
-                params[key] = data.ref.u.list.ref.values[i].u.int64;
+                params[key] = list.values[i].u.int64;
                 break;
               }
             case 'channels':
               {
-                params[key] = data.ref.u.list.ref.values[i].u.string
-                    .cast<Utf8>()
-                    .toDartString();
+                params[key] =
+                    list.values[i].u.string.cast<Utf8>().toDartString();
                 break;
               }
             case 'channel-count':
               {
-                params[key] = data.ref.u.list.ref.values[i].u.int64;
+                params[key] = list.values[i].u.int64;
                 break;
               }
             case 'hr-channels':
               {
-                params[key] = data.ref.u.list.ref.values[i].u.string
-                    .cast<Utf8>()
-                    .toDartString();
+                params[key] =
+                    list.values[i].u.string.cast<Utf8>().toDartString();
                 break;
               }
             default:
@@ -1225,8 +1167,7 @@ class Player extends PlatformPlayer {
       'pause': generated.mpv_format.MPV_FORMAT_FLAG,
       'time-pos': generated.mpv_format.MPV_FORMAT_DOUBLE,
       'duration': generated.mpv_format.MPV_FORMAT_DOUBLE,
-      'playlist-pos': generated.mpv_format.MPV_FORMAT_INT64,
-      'seekable': generated.mpv_format.MPV_FORMAT_FLAG,
+      'playlist': generated.mpv_format.MPV_FORMAT_NODE,
       'volume': generated.mpv_format.MPV_FORMAT_DOUBLE,
       'speed': generated.mpv_format.MPV_FORMAT_DOUBLE,
       'paused-for-cache': generated.mpv_format.MPV_FORMAT_FLAG,

--- a/media_kit/lib/src/libmpv/player.dart
+++ b/media_kit/lib/src/libmpv/player.dart
@@ -111,14 +111,22 @@ class Player extends PlatformPlayer {
 
     // Enter paused state.
     {
-      var name = 'pause'.toNativeUtf8();
-      var value = calloc<Uint8>()..value = 1;
-      _libmpv?.mpv_set_property(
+      final name = 'pause'.toNativeUtf8();
+      final value = calloc<Uint8>();
+      _libmpv?.mpv_get_property(
         ctx,
         name.cast(),
         generated.mpv_format.MPV_FORMAT_FLAG,
         value.cast(),
       );
+      if (value.value == 0) {
+        // We are using `cycle pause` because it waits & prevents the race condition.
+        final command = 'cycle pause'.toNativeUtf8();
+        _libmpv?.mpv_command_string(
+          ctx,
+          command.cast(),
+        );
+      }
       calloc.free(name);
       calloc.free(value);
       state = state.copyWith(playing: false);
@@ -143,13 +151,21 @@ class Player extends PlatformPlayer {
     if (play) {
       _allowPlayingStateChange = true;
       final name = 'pause'.toNativeUtf8();
-      final value = calloc<Uint8>()..value = 0;
-      _libmpv?.mpv_set_property(
+      final value = calloc<Uint8>();
+      _libmpv?.mpv_get_property(
         ctx,
         name.cast(),
         generated.mpv_format.MPV_FORMAT_FLAG,
         value.cast(),
       );
+      if (value.value == 1) {
+        // We are using `cycle pause` because it waits & prevents the race condition.
+        final command = 'cycle pause'.toNativeUtf8();
+        _libmpv?.mpv_command_string(
+          ctx,
+          command.cast(),
+        );
+      }
       calloc.free(name);
       calloc.free(value);
     }

--- a/media_kit/lib/src/media_kit.dart
+++ b/media_kit/lib/src/media_kit.dart
@@ -6,7 +6,7 @@
 
 import 'dart:io';
 
-import 'package:media_kit/src/libmpv/entry_point.dart' as _libmpv;
+import 'package:media_kit/src/libmpv/entry_point.dart' as implementation;
 
 /// {@template media_kit}
 ///
@@ -27,19 +27,19 @@ abstract class MediaKit {
   /// {@macro media_kit}
   static void ensureInitialized({String? libmpv}) {
     if (Platform.isWindows) {
-      _libmpv.ensureInitialized();
+      implementation.ensureInitialized();
     }
     if (Platform.isLinux) {
-      _libmpv.ensureInitialized();
+      implementation.ensureInitialized();
     }
     if (Platform.isMacOS) {
-      _libmpv.ensureInitialized();
+      implementation.ensureInitialized();
     }
     if (Platform.isIOS) {
-      _libmpv.ensureInitialized();
+      implementation.ensureInitialized();
     }
     if (Platform.isAndroid) {
-      _libmpv.ensureInitialized();
+      implementation.ensureInitialized();
     }
   }
 }

--- a/media_kit/lib/src/platform_player.dart
+++ b/media_kit/lib/src/platform_player.dart
@@ -208,7 +208,6 @@ abstract class PlatformPlayer {
   FutureOr<void> open(
     Playable playable, {
     bool play = true,
-    bool evictExtrasCache = true,
   }) {
     throw UnimplementedError(
       '[PlatformPlayer.open] is not implemented.',

--- a/media_kit/lib/src/platform_player.dart
+++ b/media_kit/lib/src/platform_player.dart
@@ -19,122 +19,6 @@ import 'package:media_kit/src/models/player_state.dart';
 import 'package:media_kit/src/models/playlist_mode.dart';
 import 'package:media_kit/src/models/player_streams.dart';
 
-/// {@template mpv_log_level}
-///
-/// MPVLogLevel
-/// --------------------
-/// Options to customise the [Player] libmpv backend log level.
-///
-/// {@endtemplate}
-enum MPVLogLevel {
-  /// Disable absolutely all messages.
-  none,
-
-  /// Critical/aborting errors.
-  fatal,
-
-  /// Simple errors.
-  error,
-
-  /// Possible problems.
-  warn,
-
-  /// Informational message.
-  info,
-
-  /// Noisy informational message.
-  v,
-
-  /// Very noisy technical information.
-  debug,
-
-  /// Extremely noisy.
-  trace,
-}
-
-/// {@template player_configuration}
-///
-/// PlayerConfiguration
-/// --------------------
-/// Configurable options for customizing the [Player] behavior.
-///
-/// {@endtemplate}
-class PlayerConfiguration {
-  /// Sets the log level on libmpv backend.
-  /// Default: `none`.
-  final MPVLogLevel logLevel;
-
-  /// Enables on-screen controls for libmpv backend.
-  ///
-  /// Default: `false`.
-  final bool osc;
-
-  /// Enables or disables video output for libmpv backend.
-  ///
-  /// Default: `null`.
-  final bool? vid;
-
-  /// Sets the video output driver for libmpv backend.
-  ///
-  /// Default: `null`.
-  final String? vo;
-
-  /// Enables or disables pitch shift control for libmpv backend.
-  ///
-  /// Enabling this option may result in de-syncing of audio & video.
-  /// Thus, usage in audio only applications is recommended.
-  /// This uses `scaletempo` under the hood & disables `audio-pitch-correction`.
-  ///
-  /// See: https://github.com/alexmercerind/media_kit/issues/45
-  ///
-  /// Default: `false`.
-  final bool pitch;
-
-  /// Sets the name of the underlying window & process for libmpv backend.
-  /// This is visible inside the Windows' volume mixer.
-  ///
-  /// Default: `null`.
-  final String? title;
-
-  /// Sets the demuxer cache size (in bytes) for libmpv backend.
-  ///
-  /// Default: `32` MB or `32 * 1024 * 1024` bytes.
-  final int bufferSize;
-
-  /// Sets the list of allowed protocols for libmpv backend.
-  ///
-  /// Default: `['file', 'tcp', 'tls', 'http', 'https', 'crypto', 'data']`.
-  ///
-  /// Learn more: https://ffmpeg.org/ffmpeg-protocols.html#Protocol-Options
-  final List<String> protocolWhitelist;
-
-  /// Optional callback invoked when the internals of the [Player] are initialized & ready for playback.
-  ///
-  /// Default: `null`.
-  final void Function()? ready;
-
-  /// {@macro player_configuration}
-  const PlayerConfiguration({
-    this.logLevel = MPVLogLevel.none,
-    this.osc = false,
-    this.vid,
-    this.vo = 'null',
-    this.pitch = false,
-    this.title,
-    this.bufferSize = 32 * 1024 * 1024,
-    this.ready,
-    this.protocolWhitelist = const [
-      'file',
-      'tcp',
-      'tls',
-      'http',
-      'https',
-      'crypto',
-      'data',
-    ],
-  });
-}
-
 /// {@template platform_player}
 /// PlatformPlayer
 /// --------------
@@ -413,4 +297,120 @@ abstract class PlatformPlayer {
   @protected
   final StreamController<int> heightController =
       StreamController<int>.broadcast();
+}
+
+/// {@template player_configuration}
+///
+/// PlayerConfiguration
+/// --------------------
+/// Configurable options for customizing the [Player] behavior.
+///
+/// {@endtemplate}
+class PlayerConfiguration {
+  /// Sets the log level on libmpv backend.
+  /// Default: `none`.
+  final MPVLogLevel logLevel;
+
+  /// Enables on-screen controls for libmpv backend.
+  ///
+  /// Default: `false`.
+  final bool osc;
+
+  /// Enables or disables video output for libmpv backend.
+  ///
+  /// Default: `null`.
+  final bool? vid;
+
+  /// Sets the video output driver for libmpv backend.
+  ///
+  /// Default: `null`.
+  final String? vo;
+
+  /// Enables or disables pitch shift control for libmpv backend.
+  ///
+  /// Enabling this option may result in de-syncing of audio & video.
+  /// Thus, usage in audio only applications is recommended.
+  /// This uses `scaletempo` under the hood & disables `audio-pitch-correction`.
+  ///
+  /// See: https://github.com/alexmercerind/media_kit/issues/45
+  ///
+  /// Default: `false`.
+  final bool pitch;
+
+  /// Sets the name of the underlying window & process for libmpv backend.
+  /// This is visible inside the Windows' volume mixer.
+  ///
+  /// Default: `null`.
+  final String? title;
+
+  /// Sets the demuxer cache size (in bytes) for libmpv backend.
+  ///
+  /// Default: `32` MB or `32 * 1024 * 1024` bytes.
+  final int bufferSize;
+
+  /// Sets the list of allowed protocols for libmpv backend.
+  ///
+  /// Default: `['file', 'tcp', 'tls', 'http', 'https', 'crypto', 'data']`.
+  ///
+  /// Learn more: https://ffmpeg.org/ffmpeg-protocols.html#Protocol-Options
+  final List<String> protocolWhitelist;
+
+  /// Optional callback invoked when the internals of the [Player] are initialized & ready for playback.
+  ///
+  /// Default: `null`.
+  final void Function()? ready;
+
+  /// {@macro player_configuration}
+  const PlayerConfiguration({
+    this.logLevel = MPVLogLevel.none,
+    this.osc = false,
+    this.vid,
+    this.vo = 'null',
+    this.pitch = false,
+    this.title,
+    this.bufferSize = 32 * 1024 * 1024,
+    this.ready,
+    this.protocolWhitelist = const [
+      'file',
+      'tcp',
+      'tls',
+      'http',
+      'https',
+      'crypto',
+      'data',
+    ],
+  });
+}
+
+/// {@template mpv_log_level}
+///
+/// MPVLogLevel
+/// --------------------
+/// Options to customise the [Player] libmpv backend log level.
+///
+/// {@endtemplate}
+enum MPVLogLevel {
+  /// Disable absolutely all messages.
+  none,
+
+  /// Critical/aborting errors.
+  fatal,
+
+  /// Simple errors.
+  error,
+
+  /// Possible problems.
+  warn,
+
+  /// Informational message.
+  info,
+
+  /// Noisy informational message.
+  v,
+
+  /// Very noisy technical information.
+  debug,
+
+  /// Extremely noisy.
+  trace,
 }

--- a/media_kit/lib/src/player.dart
+++ b/media_kit/lib/src/player.dart
@@ -51,11 +51,6 @@ import 'package:media_kit/src/libmpv/player.dart' as _libmpv;
 /// player.streams.rate.listen((e) => print(e));
 /// player.streams.pitch.listen((e) => print(e));
 /// player.streams.buffering.listen((e) => print(e));
-/// player.streams.audioParams.listen((e) => print(e));
-/// player.streams.audioBitrate.listen((e) => print(e));
-/// player.streams.audioDevice.listen((e) => print(e));
-/// player.streams.audioDevices.listen((e) => print(e));
-///
 ///
 /// // Open a playable [Media] or [Playlist].
 ///
@@ -65,14 +60,13 @@ import 'package:media_kit/src/libmpv/player.dart' as _libmpv;
 /// await player.open(
 ///   Playlist(
 ///     [
-///       Media('https://www.example.com/sample.mp4'),
-///       Media('rtsp://www.example.com/live'),
+///       Media('https://user-images.githubusercontent.com/28951144/229373695-22f88f13-d18f-4288-9bf1-c3e078d83722.mp4'),
+///       Media('https://user-images.githubusercontent.com/28951144/229373709-603a7a89-2105-4e1b-a5a5-a6c3567c9a59.mp4'),
+///       Media('https://user-images.githubusercontent.com/28951144/229373716-76da0a4e-225a-44e4-9ee7-3e9006dbc3e3.mp4'),
+///       Media('https://user-images.githubusercontent.com/28951144/229373718-86ce5e1d-d195-45d5-baa6-ef94041d0b90.mp4'),
+///       Media('https://user-images.githubusercontent.com/28951144/229373720-14d69157-1a56-4a78-a2f4-d7a134d7c3e9.mp4'),
 ///     ],
-///     // Select the starting index.
-///     index: 1,
 ///   ),
-///   // Select whether playback should start or not.
-///   play: false,
 /// );
 ///
 /// // Control playback state.
@@ -165,12 +159,10 @@ class Player {
   FutureOr<void> open(
     Playable playable, {
     bool play = true,
-    bool evictExtrasCache = true,
   }) {
     return platform?.open(
       playable,
       play: play,
-      evictExtrasCache: evictExtrasCache,
     );
   }
 

--- a/media_kit/test/common/sources.dart
+++ b/media_kit/test/common/sources.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as path;
+
+final sources = _Sources._();
+
+class _Sources {
+  _Sources._();
+
+  final List<String> network = [
+    'https://user-images.githubusercontent.com/28951144/229373695-22f88f13-d18f-4288-9bf1-c3e078d83722.mp4',
+    'https://user-images.githubusercontent.com/28951144/229373709-603a7a89-2105-4e1b-a5a5-a6c3567c9a59.mp4',
+    'https://user-images.githubusercontent.com/28951144/229373716-76da0a4e-225a-44e4-9ee7-3e9006dbc3e3.mp4',
+    'https://user-images.githubusercontent.com/28951144/229373718-86ce5e1d-d195-45d5-baa6-ef94041d0b90.mp4',
+    'https://user-images.githubusercontent.com/28951144/229373720-14d69157-1a56-4a78-a2f4-d7a134d7c3e9.mp4',
+  ];
+  final List<String> file = [];
+
+  Future<void> prepare() async {
+    if (_prepared) return;
+    // Download to local [File]s.
+    for (int i = 0; i < network.length; i++) {
+      final response = await http.get(Uri.parse(network[i]));
+      final destination = path.join(
+        path.dirname(Platform.script.toFilePath()),
+        network[i].split('/').last,
+      );
+      await File(destination).writeAsBytes(response.bodyBytes);
+      file.add(destination);
+    }
+    // Force forward slashes for Windows.
+    for (int i = 0; i < file.length; i++) {
+      file[i] = file[i].replaceAll(r'\', '/');
+    }
+    _prepared = true;
+  }
+
+  bool _prepared = false;
+}

--- a/media_kit/test/src/libmpv/core/initializer_test.dart
+++ b/media_kit/test/src/libmpv/core/initializer_test.dart
@@ -1,0 +1,83 @@
+/// This file is a part of media_kit (https://github.com/alexmercerind/media_kit).
+///
+/// Copyright © 2021 & onwards, Hitesh Kumar Saini <saini123hitesh@gmail.com>.
+/// All rights reserved.
+/// Use of this source code is governed by MIT license that can be found in the LICENSE file.
+
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'package:test/test.dart';
+
+import 'package:media_kit/src/libmpv/core/initializer.dart';
+import 'package:media_kit/src/libmpv/core/native_library.dart';
+
+import 'package:media_kit/generated/libmpv/bindings.dart';
+
+void main() {
+  setUp(NativeLibrary.ensureInitialized);
+  test(
+    'initializer-create',
+    () async {
+      expect(
+        create(NativeLibrary.path, (_) async {}),
+        completes,
+      );
+    },
+  );
+  test(
+    'initializer-callback',
+    () async {
+      final mpv = MPV(DynamicLibrary.open(NativeLibrary.path));
+
+      bool pause = false;
+
+      final expectPauseFalse = expectAsync0(() {
+        print(pause);
+        expect(pause, isFalse);
+      });
+      final expectPauseTrue = expectAsync0(() {
+        print(pause);
+        expect(pause, isTrue);
+      });
+
+      final handle = await create(
+        NativeLibrary.path,
+        (event) async {
+          if (event.ref.event_id == mpv_event_id.MPV_EVENT_PROPERTY_CHANGE) {
+            final prop = event.ref.data.cast<mpv_event_property>();
+            if (prop.ref.name.cast<Utf8>().toDartString() == 'pause' &&
+                prop.ref.format == mpv_format.MPV_FORMAT_FLAG) {
+              final value = prop.ref.data.cast<Bool>().value;
+              pause = value;
+              if (value) {
+                expectPauseTrue();
+              }
+              if (!value) {
+                expectPauseFalse();
+              }
+            }
+          }
+        },
+      );
+      await Future.delayed(Duration(seconds: 1));
+      {
+        final name = 'pause'.toNativeUtf8();
+        mpv.mpv_observe_property(
+          handle,
+          0,
+          name.cast(),
+          mpv_format.MPV_FORMAT_FLAG,
+        );
+        calloc.free(name);
+      }
+      {
+        final command = 'cycle pause'.toNativeUtf8();
+        mpv.mpv_command_string(
+          handle,
+          command.cast(),
+        );
+        calloc.free(command);
+      }
+    },
+  );
+}

--- a/media_kit/test/src/libmpv/core/native_library_test.dart
+++ b/media_kit/test/src/libmpv/core/native_library_test.dart
@@ -1,0 +1,33 @@
+/// This file is a part of media_kit (https://github.com/alexmercerind/media_kit).
+///
+/// Copyright © 2021 & onwards, Hitesh Kumar Saini <saini123hitesh@gmail.com>.
+/// All rights reserved.
+/// Use of this source code is governed by MIT license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:media_kit/src/libmpv/core/native_library.dart';
+
+void main() {
+  test(
+    'native-library-ensure-initialized',
+    () {
+      expect(
+        NativeLibrary.ensureInitialized,
+        returnsNormally,
+      );
+    },
+  );
+  test(
+    'native-library-path',
+    () {
+      expect(
+        () {
+          final library = NativeLibrary.path;
+          print(library);
+        },
+        returnsNormally,
+      );
+    },
+  );
+}

--- a/media_kit/test/src/models/media_test.dart
+++ b/media_kit/test/src/models/media_test.dart
@@ -1,3 +1,9 @@
+/// This file is a part of media_kit (https://github.com/alexmercerind/media_kit).
+///
+/// Copyright © 2021 & onwards, Hitesh Kumar Saini <saini123hitesh@gmail.com>.
+/// All rights reserved.
+/// Use of this source code is governed by MIT license that can be found in the LICENSE file.
+
 import 'dart:io';
 import 'package:test/test.dart';
 
@@ -5,8 +11,8 @@ import 'package:media_kit/src/models/media.dart';
 
 import '../../common/sources.dart';
 
-Future<void> main() async {
-  await sources.prepare();
+void main() {
+  setUp(sources.prepare);
   test(
     'media-uri-normalization-network',
     () {

--- a/media_kit/test/src/models/media_test.dart
+++ b/media_kit/test/src/models/media_test.dart
@@ -1,12 +1,140 @@
+import 'dart:io';
 import 'package:test/test.dart';
+
 import 'package:media_kit/src/models/media.dart';
 
-void main() {
+import '../../common/sources.dart';
+
+Future<void> main() async {
+  await sources.prepare();
   test(
-    '.encodeAssetKey() encodes non-ASCII paths',
+    'media-uri-normalization-network',
     () {
-      final path = Media.encodeAssetKey('asset://assets/audios/う.wav');
-      expect(path, equals('assets/audios/%E3%81%86.wav'));
+      for (final source in sources.network) {
+        final test = source;
+        print(test);
+        expect(
+          Media.normalizeURI(source),
+          equals(source),
+        );
+        expect(
+          Media(source).uri,
+          equals(source),
+        );
+      }
+    },
+  );
+  test(
+    'media-uri-normalization-file',
+    () async {
+      // Path
+      for (final source in sources.file) {
+        final test = source;
+        print(test);
+        expect(
+          Media.normalizeURI(test),
+          equals(source),
+        );
+        expect(
+          Media(test).uri,
+          equals(source),
+        );
+      }
+      // file:// URI
+      for (final source in sources.file) {
+        final test = Uri.file(source).toString();
+        print(test);
+        expect(
+          Media.normalizeURI(test),
+          equals(source),
+        );
+        expect(
+          Media(test).uri,
+          equals(source),
+        );
+      }
+    },
+    skip: Platform.isWindows,
+  );
+  test(
+    'media-uri-normalization-file',
+    () async {
+      // File path: forward slash separators.
+      for (final source in sources.file) {
+        final test = source;
+        print(test);
+        expect(
+          Media.normalizeURI(test),
+          equals(source),
+        );
+        expect(
+          Media(test).uri,
+          equals(source),
+        );
+      }
+      // File path: backwards slash separators.
+      for (final source in sources.file) {
+        final test = source.replaceAll('/', r'\');
+        print(test);
+        expect(
+          Media.normalizeURI(test),
+          equals(source),
+        );
+        expect(
+          Media(test).uri,
+          equals(source),
+        );
+      }
+      // file:/// URI
+      for (final source in sources.file) {
+        final test = Uri.file(source).toString();
+        print(test);
+        expect(
+          Media.normalizeURI(test),
+          equals(source),
+        );
+        expect(
+          Media(test).uri,
+          equals(source),
+        );
+      }
+      // file:// URI
+      for (final source in sources.file) {
+        final test =
+            Uri.file(source).toString().replaceAll('file:///', 'file://');
+        print(test);
+        expect(
+          Media.normalizeURI(test),
+          equals(source),
+        );
+        expect(
+          Media(test).uri,
+          equals(source),
+        );
+      }
+    },
+    skip: !Platform.isWindows,
+  );
+  test(
+    'media-uri-normalization-encode-asset-key',
+    () {
+      expect(
+        Media.encodeAssetKey('asset://videos/video_0.mp4'),
+        equals('videos/video_0.mp4'),
+      );
+      expect(
+        Media.encodeAssetKey('asset:///videos/video_0.mp4'),
+        equals('videos/video_0.mp4'),
+      );
+      // Non ASCII characters.
+      expect(
+        Media.encodeAssetKey('asset://audios/う.wav'),
+        equals('audios/%E3%81%86.wav'),
+      );
+      expect(
+        Media.encodeAssetKey('asset:///audios/う.wav'),
+        equals('audios/%E3%81%86.wav'),
+      );
     },
   );
 }

--- a/media_kit/test/src/models/media_test.dart
+++ b/media_kit/test/src/models/media_test.dart
@@ -59,7 +59,7 @@ Future<void> main() async {
   test(
     'media-uri-normalization-file',
     () async {
-      // File path: forward slash separators.
+      // Path: forward slash separators
       for (final source in sources.file) {
         final test = source;
         print(test);
@@ -72,7 +72,7 @@ Future<void> main() async {
           equals(source),
         );
       }
-      // File path: backwards slash separators.
+      // Path: backwards slash separators
       for (final source in sources.file) {
         final test = source.replaceAll('/', r'\');
         print(test);

--- a/media_kit_test/lib/common/globals.dart
+++ b/media_kit_test/lib/common/globals.dart
@@ -1,0 +1,3 @@
+import 'package:flutter/foundation.dart';
+
+final enableHardwareAcceleration = ValueNotifier<bool>(true);

--- a/media_kit_test/lib/common/widgets.dart
+++ b/media_kit_test/lib/common/widgets.dart
@@ -196,14 +196,7 @@ class _SeekBarState extends State<SeekBar> {
     return Column(
       children: [
         const SizedBox(height: 16.0),
-        if (horizontal)
-          Row(
-            children: [
-              const Spacer(),
-              TracksSelector(player: widget.player),
-            ],
-          )
-        else
+        if (!horizontal)
           Row(
             children: [
               const Spacer(),

--- a/media_kit_test/lib/main.dart
+++ b/media_kit_test/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';
+import 'package:media_kit_test/common/globals.dart';
 
 import 'tests/01.single_player_single_video.dart';
 import 'tests/02.single_player_multiple_video.dart';
@@ -50,6 +51,24 @@ class PrimaryScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: const Text('package:media_kit'),
+        actions: [
+          ValueListenableBuilder<bool>(
+            valueListenable: enableHardwareAcceleration,
+            builder: (context, value, _) => TextButton(
+              onPressed: () {
+                enableHardwareAcceleration.value =
+                    !enableHardwareAcceleration.value;
+              },
+              child: Text(
+                value ? 'H/W' : 'S/W',
+                style: const TextStyle(
+                  color: Colors.white,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 16.0),
+        ],
       ),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/media_kit_test/lib/tests/01.single_player_single_video.dart
+++ b/media_kit_test/lib/tests/01.single_player_single_video.dart
@@ -17,11 +17,7 @@ class SinglePlayerSingleVideoScreen extends StatefulWidget {
 
 class _SinglePlayerSingleVideoScreenState
     extends State<SinglePlayerSingleVideoScreen> {
-  final Player player = Player(
-    configuration: const PlayerConfiguration(
-      logLevel: MPVLogLevel.warn,
-    ),
-  );
+  final Player player = Player();
   VideoController? controller;
 
   @override

--- a/media_kit_test/lib/tests/01.single_player_single_video.dart
+++ b/media_kit_test/lib/tests/01.single_player_single_video.dart
@@ -4,6 +4,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 
+import '../common/globals.dart';
 import '../common/sources.dart';
 import '../common/widgets.dart';
 
@@ -24,7 +25,10 @@ class _SinglePlayerSingleVideoScreenState
   void initState() {
     super.initState();
     Future.microtask(() async {
-      controller = await VideoController.create(player);
+      controller = await VideoController.create(
+        player,
+        enableHardwareAcceleration: enableHardwareAcceleration.value,
+      );
       setState(() {});
     });
   }

--- a/media_kit_test/lib/tests/02.single_player_multiple_video.dart
+++ b/media_kit_test/lib/tests/02.single_player_multiple_video.dart
@@ -4,6 +4,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 
+import '../common/globals.dart';
 import '../common/sources.dart';
 import '../common/widgets.dart';
 
@@ -24,7 +25,10 @@ class _SinglePlayerMultipleVideoScreenState
   void initState() {
     super.initState();
     Future.microtask(() async {
-      controller = await VideoController.create(player);
+      controller = await VideoController.create(
+        player,
+        enableHardwareAcceleration: enableHardwareAcceleration.value,
+      );
       setState(() {});
     });
   }

--- a/media_kit_test/lib/tests/03.multiple_player_multiple_video.dart
+++ b/media_kit_test/lib/tests/03.multiple_player_multiple_video.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 
+import '../common/globals.dart';
 import '../common/sources.dart';
 import '../common/widgets.dart';
 
@@ -24,7 +25,10 @@ class _MultiplePlayerMultipleVideoScreenState
     super.initState();
     Future.microtask(() async {
       for (int i = 0; i < players.length; i++) {
-        controllers[i] = await VideoController.create(players[i]);
+        controllers[i] = await VideoController.create(
+          players[i],
+          enableHardwareAcceleration: enableHardwareAcceleration.value,
+        );
       }
       setState(() {});
     });

--- a/media_kit_test/lib/tests/04.tabs_test.dart
+++ b/media_kit_test/lib/tests/04.tabs_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 
+import '../common/globals.dart';
 import '../common/sources.dart';
 
 class TabsTest extends StatelessWidget {
@@ -62,6 +63,7 @@ class __ViewportState extends State<_Viewport> {
     Future.microtask(() async {
       controller = await VideoController.create(
         player,
+        enableHardwareAcceleration: enableHardwareAcceleration.value,
       );
       await player.open(Media(sources[widget.i]));
       await player.setPlaylistMode(PlaylistMode.loop);

--- a/media_kit_test/lib/tests/05.stress_test.dart
+++ b/media_kit_test/lib/tests/05.stress_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 
+import '../common/globals.dart';
 import '../common/sources.dart';
 
 class StressTestScreen extends StatefulWidget {
@@ -24,7 +25,10 @@ class _StressTestScreenState extends State<StressTestScreen> {
       () async {
         for (int i = 0; i < count; i++) {
           final player = Player();
-          final controller = await VideoController.create(player);
+          final controller = await VideoController.create(
+            player,
+            enableHardwareAcceleration: enableHardwareAcceleration.value,
+          );
           players.add(player);
           controllers.add(controller);
         }

--- a/media_kit_test/lib/tests/06.paint_first_frame.dart
+++ b/media_kit_test/lib/tests/06.paint_first_frame.dart
@@ -27,7 +27,10 @@ Future<void> paintFirstFrame(BuildContext context) async {
   // Do not start playback i.e. play: false.
   for (int i = 0; i < 5; i++) {
     await players[i].open(
-      Media(sources[i % sources.length]),
+      Playlist(
+        sources.map((e) => Media(e)).toList(),
+        index: i,
+      ),
       play: false,
     );
   }

--- a/media_kit_test/lib/tests/06.paint_first_frame.dart
+++ b/media_kit_test/lib/tests/06.paint_first_frame.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 
+import '../common/globals.dart';
 import '../common/sources.dart';
 
 // ignore_for_file: use_build_context_synchronously
@@ -17,11 +18,26 @@ Future<void> paintFirstFrame(BuildContext context) async {
     Player(),
   ];
   List<VideoController> controllers = [
-    await VideoController.create(players[0]),
-    await VideoController.create(players[1]),
-    await VideoController.create(players[2]),
-    await VideoController.create(players[3]),
-    await VideoController.create(players[4]),
+    await VideoController.create(
+      players[0],
+      enableHardwareAcceleration: enableHardwareAcceleration.value,
+    ),
+    await VideoController.create(
+      players[1],
+      enableHardwareAcceleration: enableHardwareAcceleration.value,
+    ),
+    await VideoController.create(
+      players[2],
+      enableHardwareAcceleration: enableHardwareAcceleration.value,
+    ),
+    await VideoController.create(
+      players[3],
+      enableHardwareAcceleration: enableHardwareAcceleration.value,
+    ),
+    await VideoController.create(
+      players[4],
+      enableHardwareAcceleration: enableHardwareAcceleration.value,
+    ),
   ];
   // Open some [Playable]s.
   // Do not start playback i.e. play: false.

--- a/media_kit_test/lib/tests/07.video_controller_set_size.dart
+++ b/media_kit_test/lib/tests/07.video_controller_set_size.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 
+import '../common/globals.dart';
 import '../common/sources.dart';
 
 class VideoControllerSetSizeScreen extends StatefulWidget {
@@ -21,7 +22,10 @@ class _VideoControllerSetSizeScreenState
   void initState() {
     super.initState();
     Future.microtask(() async {
-      controller = await VideoController.create(player);
+      controller = await VideoController.create(
+        player,
+        enableHardwareAcceleration: enableHardwareAcceleration.value,
+      );
       await player.open(Media(sources[0]));
       await player.setPlaylistMode(PlaylistMode.loop);
       await player.setVolume(0.0);

--- a/media_kit_video/android/src/main/java/com/alexmercerind/media_kit_video/MediaKitVideoPlugin.java
+++ b/media_kit_video/android/src/main/java/com/alexmercerind/media_kit_video/MediaKitVideoPlugin.java
@@ -1,6 +1,6 @@
 /**
  * This file is a part of media_kit (https://github.com/alexmercerind/media_kit).
- *
+ * <p>
  * Copyright © 2021 & onwards, Hitesh Kumar Saini <saini123hitesh@gmail.com>.
  * All rights reserved.
  * Use of this source code is governed by MIT license that can be found in the LICENSE file.
@@ -10,6 +10,7 @@ package com.alexmercerind.media_kit_video;
 import androidx.annotation.NonNull;
 
 import java.util.HashMap;
+import java.util.Objects;
 
 import com.alexmercerind.mpv.MPVLib;
 
@@ -19,7 +20,9 @@ import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 
-/** MediaKitVideoPlugin */
+/**
+ * MediaKitVideoPlugin
+ */
 public class MediaKitVideoPlugin implements FlutterPlugin, MethodCallHandler {
     private MethodChannel channel;
     private VideoOutputManager videoOutputManager;
@@ -44,26 +47,50 @@ public class MediaKitVideoPlugin implements FlutterPlugin, MethodCallHandler {
 
     @Override
     public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
-        if (call.method.equals("VideoOutputManager.Create")) {
-            final String handle = call.argument("handle");
-            if (handle != null) {
-                final VideoOutput videoOutput = videoOutputManager.create(Long.parseLong(handle));
-                final HashMap<String, Long> data = new HashMap<>();
-                data.put("id", videoOutput.id);
-                data.put("wid", videoOutput.wid);
-                result.success(data);
-            } else {
+        switch (call.method) {
+            case "VideoOutputManager.Create": {
+                final String handle = call.argument("handle");
+                if (handle != null) {
+                    final VideoOutput videoOutput = videoOutputManager.create(Long.parseLong(handle));
+                    final HashMap<String, Long> data = new HashMap<>();
+                    data.put("id", videoOutput.id);
+                    data.put("wid", videoOutput.wid);
+                    result.success(data);
+                } else {
+                    result.success(null);
+                }
+                break;
+            }
+            case "VideoOutputManager.SetSurfaceTextureSize": {
+                final String handle = call.argument("handle");
+                final String width = call.argument("width");
+                final String height = call.argument("height");
+                if (handle != null) {
+                    videoOutputManager.setSurfaceTextureSize(
+                            Long.parseLong(handle),
+                            Integer.parseInt(Objects.requireNonNull(width)),
+                            Integer.parseInt(Objects.requireNonNull(height))
+                    );
+                }
                 result.success(null);
+                break;
             }
-
-        } else if (call.method.equals("VideoOutputManager.Dispose")) {
-            final String handle = call.argument("handle");
-            if (handle != null) {
-                videoOutputManager.dispose(Long.parseLong(handle));
+            case "VideoOutputManager.Dispose": {
+                final String handle = call.argument("handle");
+                if (handle != null) {
+                    videoOutputManager.dispose(Long.parseLong(handle));
+                }
+                result.success(null);
+                break;
             }
-            result.success(null);
-        } else {
-            result.notImplemented();
+            case "Utils.IsEmulator": {
+                result.success(Utils.isEmulator());
+                break;
+            }
+            default: {
+                result.notImplemented();
+                break;
+            }
         }
     }
 

--- a/media_kit_video/android/src/main/java/com/alexmercerind/media_kit_video/Utils.java
+++ b/media_kit_video/android/src/main/java/com/alexmercerind/media_kit_video/Utils.java
@@ -1,0 +1,37 @@
+/**
+ * This file is a part of media_kit (https://github.com/alexmercerind/media_kit).
+ *
+ * Copyright © 2021 & onwards, Hitesh Kumar Saini <saini123hitesh@gmail.com>.
+ * All rights reserved.
+ * Use of this source code is governed by MIT license that can be found in the LICENSE file.
+ */
+package com.alexmercerind.media_kit_video;
+
+import android.os.Build;
+
+public abstract class Utils {
+    public static boolean isEmulator() {
+        try {
+            // https://github.com/fluttercommunity/plus_plugins/blob/ff54dc49230ee5f8b772a3326d4ff3758618df80/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt#L110-L125
+            return Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic")
+                    || Build.FINGERPRINT.startsWith("generic")
+                    || Build.FINGERPRINT.startsWith("unknown")
+                    || Build.HARDWARE.contains("goldfish")
+                    || Build.HARDWARE.contains("ranchu")
+                    || Build.MODEL.contains("google_sdk")
+                    || Build.MODEL.contains("Emulator")
+                    || Build.MODEL.contains("Android SDK built for x86")
+                    || Build.MANUFACTURER.contains("Genymotion")
+                    || Build.PRODUCT.contains("sdk_google")
+                    || Build.PRODUCT.contains("google_sdk")
+                    || Build.PRODUCT.contains("sdk")
+                    || Build.PRODUCT.contains("sdk_x86")
+                    || Build.PRODUCT.contains("vbox86p")
+                    || Build.PRODUCT.contains("emulator")
+                    || Build.PRODUCT.contains("simulator");
+        } catch(Throwable e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+}

--- a/media_kit_video/android/src/main/java/com/alexmercerind/media_kit_video/VideoOutput.java
+++ b/media_kit_video/android/src/main/java/com/alexmercerind/media_kit_video/VideoOutput.java
@@ -1,6 +1,6 @@
 /**
  * This file is a part of media_kit (https://github.com/alexmercerind/media_kit).
- *
+ * <p>
  * Copyright © 2021 & onwards, Hitesh Kumar Saini <saini123hitesh@gmail.com>.
  * All rights reserved.
  * Use of this source code is governed by MIT license that can be found in the LICENSE file.
@@ -41,12 +41,19 @@ public class VideoOutput {
 
         surfaceTextureEntry = textureRegistryReference.createSurfaceTexture();
         surface = new Surface(surfaceTextureEntry.surfaceTexture());
-
         try {
             id = surfaceTextureEntry.id();
             wid = (long) newGlobalObjectRef.invoke(null, surface);
             Log.i("media_kit", String.format(Locale.ENGLISH, "com.alexmercerind.media_kit_video.VideoOutput: id = %d", id));
             Log.i("media_kit", String.format(Locale.ENGLISH, "com.alexmercerind.media_kit_video.VideoOutput: wid = %d", wid));
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void setSurfaceTextureSize(int width, int height) {
+        try {
+            surfaceTextureEntry.surfaceTexture().setDefaultBufferSize(width, height);
         } catch (Throwable e) {
             e.printStackTrace();
         }

--- a/media_kit_video/android/src/main/java/com/alexmercerind/media_kit_video/VideoOutputManager.java
+++ b/media_kit_video/android/src/main/java/com/alexmercerind/media_kit_video/VideoOutputManager.java
@@ -35,6 +35,15 @@ public class VideoOutputManager {
         }
     }
 
+    public void setSurfaceTextureSize(long handle, int width, int height) {
+        synchronized (lock) {
+            Log.i("media_kit", String.format(Locale.ENGLISH, "com.alexmercerind.media_kit_video.VideoOutputManager.setSurfaceTextureSize: %d %d %d", handle, width, height));
+            if (videoOutputs.containsKey(handle)) {
+                Objects.requireNonNull(videoOutputs.get(handle)).setSurfaceTextureSize(width, height);
+            }
+        }
+    }
+
     public void dispose(long handle) {
         synchronized (lock) {
             Log.i("media_kit", String.format(Locale.ENGLISH, "com.alexmercerind.media_kit_video.VideoOutputManager.dispose: %d", handle));

--- a/media_kit_video/example/README.md
+++ b/media_kit_video/example/README.md
@@ -4,10 +4,20 @@ import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';                        /// Provides [Player], [Media], [Playlist] etc.
 import 'package:media_kit_video/media_kit_video.dart';            /// Provides [VideoController] & [Video] etc.
 
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  MediaKit.ensureInitialized();
+  runApp(
+    const MaterialApp(
+      home: MyScreen()
+    ),
+  );
+}
+
 class MyScreen extends StatefulWidget {
   const MyScreen({Key? key}) : super(key: key);
   @override
-  State<MyScreen> createState() => _MyScreenState();
+  State<MyScreen> createState() => MyScreenState();
 }
 
 class MyScreenState extends State<MyScreen> {

--- a/media_kit_video/lib/src/video_controller.dart
+++ b/media_kit_video/lib/src/video_controller.dart
@@ -32,10 +32,14 @@ import 'package:media_kit_video/src/video_controller_android.dart';
 ///
 /// **Notes**
 ///
-/// 1. You can limit size of the video output by specifying `width` & `height`.
-///    By default, both `height` & `width` are `null` i.e. output is based on video's resolution.
-/// 2. You can switch between GPU & CPU rendering by specifying `enableHardwareAcceleration`.
-///    By default, `enableHardwareAcceleration` is `true` i.e. GPU (Direct3D/OpenGL/METAL) is utilized.
+/// 1. You can limit size of the video output by specifying [width] & [height].
+///    By default, both [height] & [width] are `null` i.e. output is based on video's resolution.
+/// 2. You can switch between GPU & CPU rendering by specifying [enableHardwareAcceleration].
+///    By default, [enableHardwareAcceleration] is `true` i.e. GPU (Direct3D/OpenGL/METAL) is utilized.
+///
+/// **Additional Information**
+///
+/// 1. [width] & [height] arguments have no effect on Android.
 ///
 /// {@endtemplate}
 abstract class VideoController {
@@ -113,6 +117,6 @@ abstract class VideoController {
       'height: $height, '
       'enableHardwareAcceleration: $enableHardwareAcceleration, '
       'id: $id, '
-      'rect: $rect, '
+      'rect: $rect'
       ')';
 }

--- a/media_kit_video/lib/src/video_controller.dart
+++ b/media_kit_video/lib/src/video_controller.dart
@@ -61,9 +61,9 @@ abstract class VideoController {
   VideoController(
     this.player,
     this.width,
-    this.height, {
-    this.enableHardwareAcceleration = true,
-  });
+    this.height,
+    this.enableHardwareAcceleration,
+  );
 
   /// {@macro video_controller}
   static Future<VideoController> create(

--- a/media_kit_video/lib/src/video_controller_android.dart
+++ b/media_kit_video/lib/src/video_controller_android.dart
@@ -40,9 +40,9 @@ class VideoControllerAndroid extends VideoController {
   VideoControllerAndroid(
     super.player,
     super.width,
-    super.height, {
-    super.enableHardwareAcceleration = true,
-  }) {
+    super.height,
+    super.enableHardwareAcceleration,
+  ) {
     // Merge the width & height [Stream]s into a single [Stream] of [Rect]s.
     int w = -1;
     int h = -1;
@@ -130,7 +130,7 @@ class VideoControllerAndroid extends VideoController {
       player,
       width,
       height,
-      enableHardwareAcceleration: enableHardwareAcceleration,
+      enableHardwareAcceleration,
     );
     // Store the [VideoController] in the [_controllers].
     _controllers[handle] = controller;

--- a/media_kit_video/lib/src/video_controller_native.dart
+++ b/media_kit_video/lib/src/video_controller_native.dart
@@ -36,9 +36,9 @@ class VideoControllerNative extends VideoController {
   VideoControllerNative(
     super.player,
     super.width,
-    super.height, {
-    super.enableHardwareAcceleration = true,
-  });
+    super.height,
+    super.enableHardwareAcceleration,
+  );
 
   /// {@macro video_controller_native}
   static Future<VideoController> create(
@@ -60,7 +60,7 @@ class VideoControllerNative extends VideoController {
       player,
       width,
       height,
-      enableHardwareAcceleration: enableHardwareAcceleration,
+      enableHardwareAcceleration,
     );
     // Store the [VideoControllerNative] in the [_controllers].
     _controllers[handle] = controller;

--- a/media_kit_video/pubspec.yaml
+++ b/media_kit_video/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   ffi: ^2.0.1
   # WARNING: Bump before publishing to pub.dev
   media_kit: ^0.0.5+1
+  synchronized: ^3.1.0
   plugin_platform_interface: ^2.0.2
 
 dev_dependencies:

--- a/media_kit_video/windows/media_kit_video_plugin.cc
+++ b/media_kit_video/windows/media_kit_video_plugin.cc
@@ -42,6 +42,8 @@ void MediaKitVideoPlugin::HandleMethodCall(
         std::get<std::string>(arguments[flutter::EncodableValue("width")]);
     auto height =
         std::get<std::string>(arguments[flutter::EncodableValue("height")]);
+    auto enable_hardware_acceleration = std::get<bool>(
+        arguments[flutter::EncodableValue("enableHardwareAcceleration")]);
     auto handle_value =
         static_cast<int64_t>(strtoll(handle.c_str(), nullptr, 10));
     auto width_value = std::optional<int64_t>{};
@@ -51,7 +53,7 @@ void MediaKitVideoPlugin::HandleMethodCall(
       height_value = static_cast<int64_t>(strtoll(height.c_str(), nullptr, 10));
     }
     video_output_manager_->Create(
-        handle_value, width_value, height_value,
+        handle_value, width_value, height_value, enable_hardware_acceleration,
         [channel_ptr = channel_.get(), handle = handle_value](
             auto id, auto width, auto height) {
           channel_ptr->InvokeMethod(

--- a/media_kit_video/windows/video_output.h
+++ b/media_kit_video/windows/video_output.h
@@ -54,6 +54,7 @@ class VideoOutput {
   VideoOutput(int64_t handle,
               std::optional<int64_t> width,
               std::optional<int64_t> height,
+              bool enable_hardware_acceleration,
               flutter::PluginRegistrarWindows* registrar,
               ThreadPool* thread_pool_ref);
 
@@ -81,9 +82,13 @@ class VideoOutput {
   mpv_render_context* render_context_ = nullptr;
   std::optional<int64_t> height_ = std::nullopt;
   std::optional<int64_t> width_ = std::nullopt;
+  bool enable_hardware_acceleration_ = true;
   int64_t texture_id_ = 0;
   flutter::PluginRegistrarWindows* registrar_ = nullptr;
   ThreadPool* thread_pool_ref_ = nullptr;
+  // For preventing any asynchronous operations (primarily texture objects
+  // deletion after unregister in |Resize|) access this object after
+  // destruction.
   bool destroyed_ = false;
 
   std::mutex textures_mutex_ = std::mutex();

--- a/media_kit_video/windows/video_output_manager.cc
+++ b/media_kit_video/windows/video_output_manager.cc
@@ -16,12 +16,14 @@ void VideoOutputManager::Create(
     int64_t handle,
     std::optional<int64_t> width,
     std::optional<int64_t> height,
+    bool enable_hardware_acceleration,
     std::function<void(int64_t, int64_t, int64_t)> texture_update_callback) {
   std::thread([=]() {
     std::lock_guard<std::mutex> lock(mutex_);
     if (video_outputs_.find(handle) == video_outputs_.end()) {
       auto instance = std::make_unique<VideoOutput>(
-          handle, width, height, registrar_, thread_pool_.get());
+          handle, width, height, enable_hardware_acceleration, registrar_,
+          thread_pool_.get());
       instance->SetTextureUpdateCallback(texture_update_callback);
       video_outputs_.insert(std::make_pair(handle, std::move(instance)));
     }

--- a/media_kit_video/windows/video_output_manager.h
+++ b/media_kit_video/windows/video_output_manager.h
@@ -32,10 +32,12 @@ class VideoOutputManager {
       int64_t handle,
       std::optional<int64_t> width,
       std::optional<int64_t> height,
+      bool enable_hardware_acceleration,
       std::function<void(int64_t, int64_t, int64_t)> texture_update_callback);
 
   // Sets the required video output size.
-  // This forces |VideoOutput| to resize the internal OpenGL surface / D3D texture.
+  // This forces |VideoOutput| to resize the internal OpenGL surface / D3D
+  // texture.
   void SetSize(int64_t handle,
                std::optional<int64_t> width,
                std::optional<int64_t> height);


### PR DESCRIPTION
## Changes

- fix: S/W rendering fallback & `--vo=gpu` rendering on Android
- fix: video output in Android emulator (#149)
- fix: now `playlist` state/stream is populated from libmpv event instead of manually updating inside `open`/`add`/`move` etc.
- feat: preserve last rendered video frame upon `Media` playback completion
- feat(windows): `enableHardwareAcceleration` configurability 

## Others

- chore: add button to toggle between H/W & S/W rendering in test application
- chore: test `06.paint_first_frame.dart` with non-zero playlist index