### PR TITLE
feat: Add optional subtitles_view.dart

### DIFF
--- a/media_kit/lib/src/models/player_state.dart
+++ b/media_kit/lib/src/models/player_state.dart
@@ -74,6 +74,12 @@ class PlayerState {
   /// Currently playing video's height.
   final int? height;
 
+  /// Currently playing visible primary subtitles.
+  final String primarySubtitles;
+
+  /// Currently playing visible secondary subtitles.
+  final String secondarySubtitles;
+
   /// {@macro player_state}
   const PlayerState({
     this.playlist = const Playlist([]),
@@ -94,6 +100,8 @@ class PlayerState {
     this.tracks = const Tracks(),
     this.width,
     this.height,
+    this.primarySubtitles = "",
+    this.secondarySubtitles = "",
   });
 
   PlayerState copyWith({
@@ -115,6 +123,8 @@ class PlayerState {
     Tracks? tracks,
     int? width,
     int? height,
+    String? primarySubtitles,
+    String? secondarySubtitles,
   }) {
     return PlayerState(
       playlist: playlist ?? this.playlist,
@@ -135,6 +145,8 @@ class PlayerState {
       tracks: tracks ?? this.tracks,
       width: width ?? this.width,
       height: height ?? this.height,
+      primarySubtitles: primarySubtitles ?? this.primarySubtitles,
+      secondarySubtitles: secondarySubtitles ?? this.secondarySubtitles,
     );
   }
 

--- a/media_kit/lib/src/models/player_streams.dart
+++ b/media_kit/lib/src/models/player_streams.dart
@@ -83,6 +83,12 @@ class PlayerStreams {
   /// Currently playing video's height.
   final Stream<int> height;
 
+  /// Currently playing visible primary subtitles.
+  final Stream<String> primarySubtitles;
+
+  /// Currently playing visible secondary subtitles.
+  final Stream<String> secondarySubtitles;
+
   /// {@macro player_streams}
   const PlayerStreams(
     this.playlist,
@@ -105,5 +111,7 @@ class PlayerStreams {
     this.tracks,
     this.width,
     this.height,
+    this.primarySubtitles,
+    this.secondarySubtitles,
   );
 }

--- a/media_kit/lib/src/platform_player.dart
+++ b/media_kit/lib/src/platform_player.dart
@@ -61,6 +61,8 @@ abstract class PlatformPlayer {
     tracksController.stream,
     widthController.stream,
     heightController.stream,
+    primarySubtitlesController.stream,
+    secondarySubtitlesController.stream,
   );
 
   @mustCallSuper
@@ -86,6 +88,8 @@ abstract class PlatformPlayer {
           tracksController.close(),
           widthController.close(),
           heightController.close(),
+          primarySubtitlesController.close(),
+          secondarySubtitlesController.close(),
         ],
       );
 
@@ -297,6 +301,14 @@ abstract class PlatformPlayer {
   @protected
   final StreamController<int> heightController =
       StreamController<int>.broadcast();
+
+  @protected
+  final StreamController<String> primarySubtitlesController =
+      StreamController<String>.broadcast();
+
+  @protected
+  final StreamController<String> secondarySubtitlesController =
+      StreamController<String>.broadcast();
 }
 
 /// {@template player_configuration}

--- a/media_kit_test/lib/common/sources.dart
+++ b/media_kit_test/lib/common/sources.dart
@@ -14,6 +14,8 @@ Future<void> prepareSources() async {
     'https://user-images.githubusercontent.com/28951144/229373716-76da0a4e-225a-44e4-9ee7-3e9006dbc3e3.mp4',
     'https://user-images.githubusercontent.com/28951144/229373718-86ce5e1d-d195-45d5-baa6-ef94041d0b90.mp4',
     'https://user-images.githubusercontent.com/28951144/229373720-14d69157-1a56-4a78-a2f4-d7a134d7c3e9.mp4',
+    'https://user-images.githubusercontent.com/28951144/229373720-14d69157-1a56-4a78-a2f4-d7a134d7c3e9.mp4',
+    'https://github.com/ietf-wg-cellar/matroska-test-files/raw/master/test_files/test5.mkv',
   ];
   final directory = await path.getApplicationSupportDirectory();
   for (int i = 0; i < uris.length; i++) {

--- a/media_kit_test/lib/main.dart
+++ b/media_kit_test/lib/main.dart
@@ -11,6 +11,7 @@ import 'tests/06.paint_first_frame.dart';
 import 'tests/07.video_controller_set_size.dart';
 
 import 'common/sources.dart';
+import 'tests/08.single_player_with_subtitle_view.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -171,6 +172,21 @@ class PrimaryScreen extends StatelessWidget {
               Navigator.of(context).push(
                 MaterialPageRoute(
                   builder: (context) => const VideoControllerSetSizeScreen(),
+                ),
+              );
+            },
+          ),
+          ListTile(
+            title: const Text(
+              '08.single_player_with_subtitles_view.dart',
+              style: TextStyle(fontSize: 14.0),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const SinglePlayerWithSubtitleViewScreen(),
                 ),
               );
             },

--- a/media_kit_test/lib/tests/08.single_player_with_subtitle_view.dart
+++ b/media_kit_test/lib/tests/08.single_player_with_subtitle_view.dart
@@ -1,0 +1,206 @@
+import 'package:flutter/material.dart';
+import 'package:file_picker/file_picker.dart';
+
+import 'package:media_kit/media_kit.dart';
+import 'package:media_kit_video/media_kit_video.dart';
+
+import '../common/globals.dart';
+import '../common/sources.dart';
+import '../common/widgets.dart';
+
+class SinglePlayerWithSubtitleViewScreen extends StatefulWidget {
+  const SinglePlayerWithSubtitleViewScreen({Key? key}) : super(key: key);
+
+  @override
+  State<SinglePlayerWithSubtitleViewScreen> createState() => _SinglePlayerWithSubtitleViewScreenState();
+}
+
+class _SinglePlayerWithSubtitleViewScreenState extends State<SinglePlayerWithSubtitleViewScreen> {
+  final Player player = Player();
+  VideoController? controller;
+
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() async {
+      controller = await VideoController.create(
+        player,
+        enableHardwareAcceleration: enableHardwareAcceleration.value,
+      );
+      setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    Future.microtask(() async {
+      debugPrint('Disposing [Player] and [VideoController]...');
+      await controller?.dispose();
+      await player.dispose();
+    });
+    super.dispose();
+  }
+
+  List<Widget> get items => [
+        for (int i = 0; i < sources.length; i++)
+          ListTile(
+            title: Text(
+              'Video $i',
+              style: const TextStyle(
+                fontSize: 14.0,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+            onTap: () {
+              player.open(Media(sources[i]));
+            },
+          ),
+      ];
+
+  @override
+  Widget build(BuildContext context) {
+    final horizontal = MediaQuery.of(context).size.width > MediaQuery.of(context).size.height;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('package:media_kit'),
+      ),
+      floatingActionButton: Row(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.end,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          FloatingActionButton(
+            heroTag: 'file',
+            tooltip: 'Open [File]',
+            onPressed: () async {
+              final result = await FilePicker.platform.pickFiles(
+                type: FileType.any,
+              );
+              if (result?.files.isNotEmpty ?? false) {
+                await player.open(Media(result!.files.first.path!));
+              }
+            },
+            child: const Icon(Icons.file_open),
+          ),
+          const SizedBox(width: 16.0),
+          FloatingActionButton(
+            heroTag: 'uri',
+            tooltip: 'Open [Uri]',
+            onPressed: () => showURIPicker(context, player),
+            child: const Icon(Icons.link),
+          ),
+        ],
+      ),
+      body: SizedBox.expand(
+        child: horizontal
+            ? Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Expanded(
+                    flex: 3,
+                    child: Container(
+                      alignment: Alignment.center,
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Expanded(
+                            child: Card(
+                              elevation: 8.0,
+                              clipBehavior: Clip.antiAlias,
+                              margin: const EdgeInsets.all(32.0),
+                              child: Stack(
+                                fit: StackFit.expand,
+                                children: [
+                                  Video(
+                                    controller: controller,
+                                  ),
+                                  DefaultTextStyle(
+                                    style: Theme.of(context).textTheme.bodyLarge!.copyWith(
+                                      color: Colors.yellow,
+                                      backgroundColor: Colors.red,
+                                    ),
+                                    child: Padding(
+                                      padding: const EdgeInsets.all(24),
+                                      child: SubtitlesView(player: player)
+                                    )
+                                  ),
+                                  Align(
+                                    alignment: Alignment.bottomRight,
+                                    child: Padding(
+                                      padding: const EdgeInsets.all(12),
+                                      child: PopupMenuButton<SubtitleTrack>(
+                                        icon: const Icon(Icons.subtitles, color: Colors.white),
+                                        itemBuilder: _subtitleItemBuilder,
+                                        onSelected: (final track) async {
+                                          await player.setSubtitleTrack(track);
+                                        },
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                          SeekBar(player: player),
+                          const SizedBox(height: 32.0),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const VerticalDivider(width: 1.0, thickness: 1.0),
+                  Expanded(
+                    flex: 1,
+                    child: ListView(
+                      children: items,
+                    ),
+                  ),
+                ],
+              )
+            : ListView(
+                children: [
+                  Video(
+                    controller: controller,
+                    width: MediaQuery.of(context).size.width,
+                    height: MediaQuery.of(context).size.width * 9.0 / 16.0,
+                  ),
+                  const SizedBox(height: 16.0),
+                  SeekBar(player: player),
+                  const SizedBox(height: 32.0),
+                  const Divider(height: 1.0, thickness: 1.0),
+                  ...items,
+                ],
+              ),
+      ),
+    );
+  }
+
+  List<PopupMenuItem<SubtitleTrack>> _subtitleItemBuilder(final BuildContext context) {
+    final currentTrack = player.state.track.subtitle;
+    return player.state
+        .tracks
+        .subtitle
+        .map((e) {
+          return PopupMenuItem(
+            value: e,
+            child: RichText(
+              text: TextSpan(
+                  children: [
+                    WidgetSpan(
+                      child: Padding(
+                        padding: const EdgeInsets.only(right: 8),
+                        child: Icon(Icons.check, color: e.id == currentTrack.id ? null : Colors.transparent),
+                      ),
+                    ),
+                    TextSpan(
+                      text: e.title == null || e.title?.isEmpty == true ? "Track ${e.id}${e.language == null ? "" : " (${e.language})"}" : e.title!,
+                      style: Theme.of(context).textTheme.labelLarge,
+                    ),
+                  ]
+              ),
+            ),
+          );
+        })
+        .toList(growable: false);
+  }
+}

--- a/media_kit_video/lib/media_kit_video.dart
+++ b/media_kit_video/lib/media_kit_video.dart
@@ -6,3 +6,4 @@
 
 export 'package:media_kit_video/src/video.dart';
 export 'package:media_kit_video/src/video_controller.dart';
+export 'package:media_kit_video/src/subtitles_view.dart';

--- a/media_kit_video/lib/src/subtitles_view.dart
+++ b/media_kit_video/lib/src/subtitles_view.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:media_kit/media_kit.dart';
+
+class SubtitlesView extends StatefulWidget {
+
+  final Player player;
+  const SubtitlesView({super.key, required this.player});
+
+  @override
+  State<SubtitlesView> createState() => _SubtitlesViewState();
+
+}
+
+class _SubtitlesViewState extends State<SubtitlesView> {
+
+
+  bool isDisabled = true;
+  String? primarySubtitles;
+  String? secondarySubtitles;
+
+  final subscriptions = <StreamSubscription>[];
+
+  @override
+  void initState() {
+    super.initState();
+    final player = widget.player;
+    final platform = player.platform;
+    if (platform is libmpvPlayer) {
+      platform.setProperty("sub-visibility", "no");
+      platform.setProperty("secondary-sub-visibility", "no");
+    }
+    subscriptions.addAll([
+      player.streams.track.listen( (final event) {
+        final isDisabled = event.subtitle == SubtitleTrack.no();
+        if (isDisabled != this.isDisabled && mounted) {
+          setState(() {
+            this.isDisabled = isDisabled;
+          });
+        }
+      }),
+      player.streams.primarySubtitles.listen((final event) {
+        if (!mounted || primarySubtitles == event) {
+          return;
+        }
+        setState(() {
+          primarySubtitles = event;
+        });
+      }),
+      player.streams.secondarySubtitles.listen((final event) {
+        if (!mounted || secondarySubtitles == event) {
+          return;
+        }
+        setState(() {
+          secondarySubtitles = event;
+        });
+      }),
+    ]);
+  }
+
+  @override
+  void dispose() {
+    final player = widget.player;
+    final platform = player.platform;
+    if (platform is libmpvPlayer) {
+      platform.setProperty("sub-visibility", "yes");
+      platform.setProperty("secondary-sub-visibility", "yes");
+    }
+    for (final subscription in subscriptions) {
+      subscription.cancel();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Visibility(
+      visible: !isDisabled,
+      child: Column(
+        children: [
+          Text(secondarySubtitles ?? "",textAlign: TextAlign.center),
+          const Spacer(),
+          Text(primarySubtitles ?? "", textAlign: TextAlign.center),
+        ],
+      ),
+    );
+  }
+
+}


### PR DESCRIPTION
I added backbone  `SubtitlesView` for displaying subtitles.

This option might be relevant for Android phones when dev chooses a video output that is not compatible with MPV's subtitles engine.

This is a simple feature and can be improved with more customization or optimisation

Feel free to leave any suggestion or edit code.

Font size, color, background, etc... can be customized by wrapping with `DefaultTextStyle` widget

![Capture d’écran 2023-04-27 à 20 19 43](https://user-images.githubusercontent.com/57662334/234956231-91167436-71d1-4882-9a4f-c921dc65d2e8.png)
