### PR TITLE
fix(darwin): fix pubspec.lock search in podspec

### DIFF
--- a/media_kit_native_event_loop/common/darwin/Podspec/media_kit_utils.rb
+++ b/media_kit_native_event_loop/common/darwin/Podspec/media_kit_utils.rb
@@ -1,0 +1,98 @@
+# `MediaKitUtils` is duplicated across:
+# - `media_kit_video`
+# - `media_kit_native_event_loop`
+class MediaKitUtils
+  attr_accessor :libs_found, :libs_package
+
+  module Platform
+    IOS   ||= 'ios'
+    MACOS ||= 'macos'
+  end
+
+  module Type
+    AUDIO ||= 'audio'
+    VIDEO ||= 'video'
+  end
+
+  def initialize(platform)
+    raise "Expecting '#{Platform::IOS}' or '#{Platform::MACOS}': platform = #{platform}" if
+      !(platform == Platform::IOS || platform == Platform::MACOS)
+
+    # Find the nearest path to `pubspec.lock` using `PWD` env var set by
+    # `cocoapods`
+    current_dir       = ENV['PWD'] || '/'
+    pubspec_lock_path = MediaKitUtils::find_nearest_pubspec_lock(current_dir)
+
+    # If not found try again using `PWD_FALLBACK` env var manually set,
+    # `PWD_FALLBACK` must point to app folder or any child folder
+    if pubspec_lock_path == ''
+      current_dir       = ENV['PWD_FALLBACK'] || '/'
+      pubspec_lock_path = MediaKitUtils::find_nearest_pubspec_lock(current_dir)
+    end
+
+    # Abort if no `pubspec.lock` was found
+    if pubspec_lock_path == ''
+      abort(
+        sprintf(
+          'media_kit: ERROR: No pubspec.lock was found: ENV["PWD"] = "%s"',
+          ENV["PWD"]
+        )
+      )
+    end
+
+    # Load packages from `pubspec.lock`
+    pubspec_lock          = YAML.load_file(pubspec_lock_path)
+    packages              = pubspec_lock['packages']
+    
+    # Checks for `media_kit_libs_***` in `pubspec.lock`
+    libs_count    = 0
+    @libs_package = ''
+    Type.constants.each do |constant|
+      type    = Type.const_get(constant)
+      package = sprintf('media_kit_libs_%s_%s', platform, type)
+      if packages.keys.include?(package)
+        libs_count    += 1
+        @libs_package = package
+
+        puts sprintf('media_kit: INFO: package:%s found', package)
+      end
+    end
+
+    # Abort if multiple `media_kit_libs_***` was found
+    if libs_count > 1
+      abort(
+        sprintf(
+          'media_kit: ERROR: package:media_kit_libs_%s_*** must be uniq',
+          platform,
+        )
+      )
+    end
+
+    @libs_found = libs_count > 0
+
+    # Warn if no `media_kit_libs_*` was found
+    if !@libs_found
+      warn(
+        sprintf(
+          'media_kit: WARNING: package:media_kit_libs_%s_*** not found',
+          platform
+        )
+      )
+    end
+  end
+
+  # Looks for the nearest `pubspec.lock` by recursively ascending through the
+  # parent folders
+  def self.find_nearest_pubspec_lock(current_dir)
+    while current_dir != '/'
+      path = File.join(current_dir, 'pubspec.lock')
+      if File.exist?(path)
+        return path
+      else
+        current_dir = File.expand_path('..', current_dir)
+      end
+    end
+
+    return ''
+  end
+end

--- a/media_kit_native_event_loop/ios/media_kit_native_event_loop.podspec
+++ b/media_kit_native_event_loop/ios/media_kit_native_event_loop.podspec
@@ -2,51 +2,15 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
 # Run `pod lib lint media_kit_native_event_loop.podspec` to validate before publishing.
 #
+
+require_relative '../common/darwin/Podspec/media_kit_utils.rb'
+
 Pod::Spec.new do |s|
   # Setup required files
   system("make -C ../common/darwin")
 
-  # Find the nearest path to `pubspec.lock`
-  current_dir       = ENV['PWD']
-  pubspec_lock_path = ''
-  while pubspec_lock_path == '' && current_dir != '/'
-    path = File.join(current_dir, 'pubspec.lock')
-    if File.exist?(path)
-      pubspec_lock_path = path
-    else
-      current_dir = File.expand_path('..', current_dir)
-    end
-  end
-
-  # Fail if no `pubspec.lock` was found
-  if pubspec_lock_path == ''
-    abort(
-      sprintf('ERROR: No pubspec.lock was found: ENV["PWD"] = "%s"', ENV["PWD"])
-    )
-  end
-
-  # Checks for `media_kit_libs_*` in `pubspec.lock`
-  pubspec_lock           = YAML.load_file(pubspec_lock_path)
-  packages               = pubspec_lock['packages']
-  libs_audio_dep_found   = packages.keys.include?('media_kit_libs_ios_audio')
-  libs_video_dep_found   = packages.keys.include?('media_kit_libs_ios_video')
-  libs_dep_found         = libs_audio_dep_found || libs_video_dep_found
-
-  # Warn if no `media_kit_libs_*` is found
-  if !libs_dep_found
-    warn("media_kit: WARNING: package:media_kit_libs_*** not found")
-  end
-
-  # Define paths to frameworks dir
-  framework_search_paths_iphoneos        = ''
-  framework_search_paths_iphonesimulator = ''
-  if libs_audio_dep_found
-    framework_search_paths_iphoneos        = '$(PROJECT_DIR)/../.symlinks/plugins/media_kit_libs_ios_audio/ios/Frameworks/MPV.xcframework/ios-arm64'
-    framework_search_paths_iphonesimulator = '$(PROJECT_DIR)/../.symlinks/plugins/media_kit_libs_ios_audio/ios/Frameworks/MPV.xcframework/ios-arm64_x86_64-simulator'
-  elsif libs_video_dep_found
-    framework_search_paths_iphoneos        = '$(PROJECT_DIR)/../.symlinks/plugins/media_kit_libs_ios_video/ios/Frameworks/MPV.xcframework/ios-arm64'
-    framework_search_paths_iphonesimulator = '$(PROJECT_DIR)/../.symlinks/plugins/media_kit_libs_ios_video/ios/Frameworks/MPV.xcframework/ios-arm64_x86_64-simulator'
-  end
+  # Initialize `MediaKitUtils`
+  mku = MediaKitUtils.new(MediaKitUtils::Platform::IOS)
 
   s.name             = 'media_kit_native_event_loop'
   s.version          = '1.0.0'
@@ -65,7 +29,11 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.dependency         'Flutter'
 
-  if libs_dep_found
+  if mku.libs_found
+    # Define paths to frameworks dir
+    framework_search_paths_iphoneos        = sprintf('$(PROJECT_DIR)/../.symlinks/plugins/%s/ios/Frameworks/MPV.xcframework/ios-arm64', mku.libs_package)
+    framework_search_paths_iphonesimulator = sprintf('$(PROJECT_DIR)/../.symlinks/plugins/%s/ios/Frameworks/MPV.xcframework/ios-arm64_x86_64-simulator', mku.libs_package)
+
     s.source_files        = 'Classes/**/*'
     s.platform            = :ios, '13.0'
     s.swift_version       = '5.0'

--- a/media_kit_native_event_loop/macos/media_kit_native_event_loop.podspec
+++ b/media_kit_native_event_loop/macos/media_kit_native_event_loop.podspec
@@ -2,48 +2,15 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
 # Run `pod lib lint media_kit_native_event_loop.podspec` to validate before publishing.
 #
+
+require_relative '../common/darwin/Podspec/media_kit_utils.rb'
+
 Pod::Spec.new do |s|
   # Setup required files
   system("make -C ../common/darwin")
 
-  # Find the nearest path to `pubspec.lock`
-  current_dir       = ENV['PWD']
-  pubspec_lock_path = ''
-  while pubspec_lock_path == '' && current_dir != '/'
-    path = File.join(current_dir, 'pubspec.lock')
-    if File.exist?(path)
-      pubspec_lock_path = path
-    else
-      current_dir = File.expand_path('..', current_dir)
-    end
-  end
-
-  # Fail if no `pubspec.lock` was found
-  if pubspec_lock_path == ''
-    abort(
-      sprintf('ERROR: No pubspec.lock was found: ENV["PWD"] = "%s"', ENV["PWD"])
-    )
-  end
-
-  # Checks for `media_kit_libs_*` in `pubspec.lock`
-  pubspec_lock           = YAML.load_file(pubspec_lock_path)
-  packages               = pubspec_lock['packages']
-  libs_audio_dep_found   = packages.keys.include?('media_kit_libs_macos_audio')
-  libs_video_dep_found   = packages.keys.include?('media_kit_libs_macos_video')
-  libs_dep_found         = libs_audio_dep_found || libs_video_dep_found
-
-  # Warn if no `media_kit_libs_*` is found
-  if !libs_dep_found
-    warn("media_kit: WARNING: package:media_kit_libs_*** not found")
-  end
-
-  # Define paths to frameworks dir
-  framework_search_paths_macosx = ''
-  if libs_audio_dep_found
-    framework_search_paths_macosx = '$(PROJECT_DIR)/../Flutter/ephemeral/.symlinks/plugins/media_kit_libs_macos_audio/macos/Frameworks/MPV.xcframework/macos-arm64_x86_64'
-  elsif libs_video_dep_found
-    framework_search_paths_macosx = '$(PROJECT_DIR)/../Flutter/ephemeral/.symlinks/plugins/media_kit_libs_macos_video/macos/Frameworks/MPV.xcframework/macos-arm64_x86_64'
-  end
+  # Initialize `MediaKitUtils`
+  mku = MediaKitUtils.new(MediaKitUtils::Platform::MACOS)
 
   s.name             = 'media_kit_native_event_loop'
   s.version          = '1.0.0'
@@ -62,7 +29,10 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.dependency         'FlutterMacOS'
 
-  if libs_dep_found
+  if mku.libs_found
+    # Define paths to frameworks dir
+    framework_search_paths_macosx = sprintf('$(PROJECT_DIR)/../Flutter/ephemeral/.symlinks/plugins/%s/macos/Frameworks/MPV.xcframework/macos-arm64_x86_64', mku.libs_package)
+
     s.source_files        = 'Classes/**/*'
     s.platform            = :osx, '10.9'
     s.swift_version       = '5.0'

--- a/media_kit_video/common/darwin/Podspec/media_kit_utils.rb
+++ b/media_kit_video/common/darwin/Podspec/media_kit_utils.rb
@@ -1,0 +1,98 @@
+# `MediaKitUtils` is duplicated across:
+# - `media_kit_video`
+# - `media_kit_native_event_loop`
+class MediaKitUtils
+  attr_accessor :libs_found, :libs_package
+
+  module Platform
+    IOS   ||= 'ios'
+    MACOS ||= 'macos'
+  end
+
+  module Type
+    AUDIO ||= 'audio'
+    VIDEO ||= 'video'
+  end
+
+  def initialize(platform)
+    raise "Expecting '#{Platform::IOS}' or '#{Platform::MACOS}': platform = #{platform}" if
+      !(platform == Platform::IOS || platform == Platform::MACOS)
+
+    # Find the nearest path to `pubspec.lock` using `PWD` env var set by
+    # `cocoapods`
+    current_dir       = ENV['PWD'] || '/'
+    pubspec_lock_path = MediaKitUtils::find_nearest_pubspec_lock(current_dir)
+
+    # If not found try again using `PWD_FALLBACK` env var manually set,
+    # `PWD_FALLBACK` must point to app folder or any child folder
+    if pubspec_lock_path == ''
+      current_dir       = ENV['PWD_FALLBACK'] || '/'
+      pubspec_lock_path = MediaKitUtils::find_nearest_pubspec_lock(current_dir)
+    end
+
+    # Abort if no `pubspec.lock` was found
+    if pubspec_lock_path == ''
+      abort(
+        sprintf(
+          'media_kit: ERROR: No pubspec.lock was found: ENV["PWD"] = "%s"',
+          ENV["PWD"]
+        )
+      )
+    end
+
+    # Load packages from `pubspec.lock`
+    pubspec_lock          = YAML.load_file(pubspec_lock_path)
+    packages              = pubspec_lock['packages']
+    
+    # Checks for `media_kit_libs_***` in `pubspec.lock`
+    libs_count    = 0
+    @libs_package = ''
+    Type.constants.each do |constant|
+      type    = Type.const_get(constant)
+      package = sprintf('media_kit_libs_%s_%s', platform, type)
+      if packages.keys.include?(package)
+        libs_count    += 1
+        @libs_package = package
+
+        puts sprintf('media_kit: INFO: package:%s found', package)
+      end
+    end
+
+    # Abort if multiple `media_kit_libs_***` was found
+    if libs_count > 1
+      abort(
+        sprintf(
+          'media_kit: ERROR: package:media_kit_libs_%s_*** must be uniq',
+          platform,
+        )
+      )
+    end
+
+    @libs_found = libs_count > 0
+
+    # Warn if no `media_kit_libs_*` was found
+    if !@libs_found
+      warn(
+        sprintf(
+          'media_kit: WARNING: package:media_kit_libs_%s_*** not found',
+          platform
+        )
+      )
+    end
+  end
+
+  # Looks for the nearest `pubspec.lock` by recursively ascending through the
+  # parent folders
+  def self.find_nearest_pubspec_lock(current_dir)
+    while current_dir != '/'
+      path = File.join(current_dir, 'pubspec.lock')
+      if File.exist?(path)
+        return path
+      else
+        current_dir = File.expand_path('..', current_dir)
+      end
+    end
+
+    return ''
+  end
+end

--- a/media_kit_video/ios/media_kit_video.podspec
+++ b/media_kit_video/ios/media_kit_video.podspec
@@ -2,51 +2,15 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
 # Run `pod lib lint media_kit_video.podspec` to validate before publishing.
 #
+
+require_relative '../common/darwin/Podspec/media_kit_utils.rb'
+
 Pod::Spec.new do |s|
   # Setup required files
   system("make -C ../common/darwin HEADERS_DESTDIR=\"$(pwd)/Headers\"")
 
-  # Find the nearest path to `pubspec.lock`
-  current_dir       = ENV['PWD']
-  pubspec_lock_path = ''
-  while pubspec_lock_path == '' && current_dir != '/'
-    path = File.join(current_dir, 'pubspec.lock')
-    if File.exist?(path)
-      pubspec_lock_path = path
-    else
-      current_dir = File.expand_path('..', current_dir)
-    end
-  end
-
-  # Fail if no `pubspec.lock` was found
-  if pubspec_lock_path == ''
-    abort(
-      sprintf('ERROR: No pubspec.lock was found: ENV["PWD"] = "%s"', ENV["PWD"])
-    )
-  end
-
-  # Checks for `media_kit_libs_*` in `pubspec.lock`
-  pubspec_lock           = YAML.load_file(pubspec_lock_path)
-  packages               = pubspec_lock['packages']
-  libs_audio_dep_found   = packages.keys.include?('media_kit_libs_ios_audio')
-  libs_video_dep_found   = packages.keys.include?('media_kit_libs_ios_video')
-  libs_dep_found         = libs_audio_dep_found || libs_video_dep_found
-
-  # Warn if no `media_kit_libs_*` is found
-  if !libs_dep_found
-    warn("media_kit: WARNING: package:media_kit_libs_*** not found")
-  end
-
-  # Define paths to frameworks dir
-  framework_search_paths_iphoneos        = ''
-  framework_search_paths_iphonesimulator = ''
-  if libs_audio_dep_found
-    framework_search_paths_iphoneos        = '$(PROJECT_DIR)/../.symlinks/plugins/media_kit_libs_ios_audio/ios/Frameworks/MPV.xcframework/ios-arm64'
-    framework_search_paths_iphonesimulator = '$(PROJECT_DIR)/../.symlinks/plugins/media_kit_libs_ios_audio/ios/Frameworks/MPV.xcframework/ios-arm64_x86_64-simulator'
-  elsif libs_video_dep_found
-    framework_search_paths_iphoneos        = '$(PROJECT_DIR)/../.symlinks/plugins/media_kit_libs_ios_video/ios/Frameworks/MPV.xcframework/ios-arm64'
-    framework_search_paths_iphonesimulator = '$(PROJECT_DIR)/../.symlinks/plugins/media_kit_libs_ios_video/ios/Frameworks/MPV.xcframework/ios-arm64_x86_64-simulator'
-  end
+  # Initialize `MediaKitUtils`
+  mku = MediaKitUtils.new(MediaKitUtils::Platform::IOS)
 
   s.name             = 'media_kit_video'
   s.version          = '0.0.1'
@@ -63,7 +27,11 @@ Pod::Spec.new do |s|
   s.swift_version    = '5.0'
   s.dependency         'Flutter'
   
-  if libs_dep_found
+  if mku.libs_found
+    # Define paths to frameworks dir
+    framework_search_paths_iphoneos        = sprintf('$(PROJECT_DIR)/../.symlinks/plugins/%s/ios/Frameworks/MPV.xcframework/ios-arm64', mku.libs_package)
+    framework_search_paths_iphonesimulator = sprintf('$(PROJECT_DIR)/../.symlinks/plugins/%s/ios/Frameworks/MPV.xcframework/ios-arm64_x86_64-simulator', mku.libs_package)
+
     s.source_files        = 'Classes/plugin/**/*.swift', 'Headers/**/*.h'
     s.pod_target_xcconfig = {
       'DEFINES_MODULE'                               => 'YES',

--- a/media_kit_video/macos/media_kit_video.podspec
+++ b/media_kit_video/macos/media_kit_video.podspec
@@ -2,48 +2,15 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
 # Run `pod lib lint media_kit_video.podspec` to validate before publishing.
 #
+
+require_relative '../common/darwin/Podspec/media_kit_utils.rb'
+
 Pod::Spec.new do |s|
   # Setup required files
   system("make -C ../common/darwin HEADERS_DESTDIR=\"$(pwd)/Headers\"")
 
-  # Find the nearest path to `pubspec.lock`
-  current_dir       = ENV['PWD']
-  pubspec_lock_path = ''
-  while pubspec_lock_path == '' && current_dir != '/'
-    path = File.join(current_dir, 'pubspec.lock')
-    if File.exist?(path)
-      pubspec_lock_path = path
-    else
-      current_dir = File.expand_path('..', current_dir)
-    end
-  end
-
-  # Fail if no `pubspec.lock` was found
-  if pubspec_lock_path == ''
-    abort(
-      sprintf('ERROR: No pubspec.lock was found: ENV["PWD"] = "%s"', ENV["PWD"])
-    )
-  end
-
-  # Checks for `media_kit_libs_*` in `pubspec.lock`
-  pubspec_lock           = YAML.load_file(pubspec_lock_path)
-  packages               = pubspec_lock['packages']
-  libs_audio_dep_found   = packages.keys.include?('media_kit_libs_macos_audio')
-  libs_video_dep_found   = packages.keys.include?('media_kit_libs_macos_video')
-  libs_dep_found         = libs_audio_dep_found || libs_video_dep_found
-
-  # Warn if no `media_kit_libs_*` is found
-  if !libs_dep_found
-    warn("media_kit: WARNING: package:media_kit_libs_*** not found")
-  end
-
-  # Define paths to frameworks dir
-  framework_search_paths_macosx = ''
-  if libs_audio_dep_found
-    framework_search_paths_macosx = '$(PROJECT_DIR)/../Flutter/ephemeral/.symlinks/plugins/media_kit_libs_macos_audio/macos/Frameworks/MPV.xcframework/macos-arm64_x86_64'
-  elsif libs_video_dep_found
-    framework_search_paths_macosx = '$(PROJECT_DIR)/../Flutter/ephemeral/.symlinks/plugins/media_kit_libs_macos_video/macos/Frameworks/MPV.xcframework/macos-arm64_x86_64'
-  end
+  # Initialize `MediaKitUtils`
+  mku = MediaKitUtils.new(MediaKitUtils::Platform::MACOS)
 
   s.name             = 'media_kit_video'
   s.version          = '0.0.1'
@@ -60,7 +27,10 @@ Pod::Spec.new do |s|
   s.swift_version    = '5.0'
   s.dependency         'FlutterMacOS'
 
-  if libs_dep_found
+  if mku.libs_found
+    # Define paths to frameworks dir
+    framework_search_paths_macosx = sprintf('$(PROJECT_DIR)/../Flutter/ephemeral/.symlinks/plugins/%s/macos/Frameworks/MPV.xcframework/macos-arm64_x86_64', mku.libs_package)
+
     s.source_files        = 'Classes/plugin/**/*.swift', 'Headers/**/*.h'
     s.pod_target_xcconfig = {
       'DEFINES_MODULE'                      => 'YES',


### PR DESCRIPTION
Fix #159, handling `PWD_FALLBACK` manually set in a CI.

Also, prevent future issues like #172.