### PR TITLE
fix(android): shutdown leak

### DIFF
--- a/media_kit/lib/src/libmpv/core/initializer_native_event_loop.dart
+++ b/media_kit/lib/src/libmpv/core/initializer_native_event_loop.dart
@@ -79,7 +79,6 @@ abstract class InitializerNativeEventLoop {
 
     // Create [mpv_handle] & initialize it.
     final mpv = MPV(DynamicLibrary.open(path));
-    globalMpv ??= mpv;
 
     final handle = mpv.mpv_create();
 
@@ -112,8 +111,6 @@ abstract class InitializerNativeEventLoop {
 
     return handle;
   }
-
-  static MPV? globalMpv;
 
   /// [ReceivePort] used to listen for `mpv_event`(s) from the native event loop.
   /// A single [ReceivePort] is used for multiple instances.

--- a/media_kit/lib/src/libmpv/core/initializer_native_event_loop.dart
+++ b/media_kit/lib/src/libmpv/core/initializer_native_event_loop.dart
@@ -120,11 +120,15 @@ abstract class InitializerNativeEventLoop {
         try {
           final handle = message[0] as int;
           final event = Pointer<mpv_event>.fromAddress(message[1]);
-          await _callbacks[handle]?.call(event);
 
+          final callback = _callbacks[handle];
           if (event.ref.event_id == mpv_event_id.MPV_EVENT_SHUTDOWN) {
+            // First remove from callbacks list before calling callback to prevent weird races.
             _callbacks.remove(handle);
           }
+
+          // Notify public event handler.
+          await callback?.call(event);
         } catch (exception, stacktrace) {
           print(exception);
           print(stacktrace);

--- a/media_kit/lib/src/libmpv/core/initializer_native_event_loop.dart
+++ b/media_kit/lib/src/libmpv/core/initializer_native_event_loop.dart
@@ -123,17 +123,10 @@ abstract class InitializerNativeEventLoop {
         try {
           final handle = message[0] as int;
           final event = Pointer<mpv_event>.fromAddress(message[1]);
+          await _callbacks[handle]?.call(event);
+
           if (event.ref.event_id == mpv_event_id.MPV_EVENT_SHUTDOWN) {
             _callbacks.remove(handle);
-
-            // if android, also call mpv_terminate_destroy
-            if(Platform.isAndroid){
-              print("DESTROYED!!!!");
-              globalMpv?.mpv_terminate_destroy(Pointer.fromAddress(handle));
-            }
-          } else {
-            // Notify public event handler.
-            await _callbacks[handle]?.call(event);
           }
         } catch (exception, stacktrace) {
           print(exception);

--- a/media_kit/lib/src/libmpv/player.dart
+++ b/media_kit/lib/src/libmpv/player.dart
@@ -1686,7 +1686,7 @@ class Player extends PlatformPlayer {
   final Completer<Pointer<generated.mpv_handle>> _handle =
       Completer<Pointer<generated.mpv_handle>>();
 
-  // [Completer] that signifies that `MPV_EVENT_SHUTDOWN`
+  // [Completer] that signifies that the `MPV_EVENT_SHUTDOWN` event was received. 
   final Completer<void> _mpvShutdownComplete = Completer<void>();
 
   /// A simple flag to prevent changes to [state.playing] due to `loadfile` commands in [open].

--- a/media_kit/lib/src/libmpv/player.dart
+++ b/media_kit/lib/src/libmpv/player.dart
@@ -81,6 +81,11 @@ class Player extends PlatformPlayer {
         command.cast(),
       );
       calloc.free(command);
+
+      // Wake up in order to stop hanging mpv_wait_event within event loop.
+      _libmpv?.mpv_wakeup(ctx);
+
+
       super.dispose();
     }
 

--- a/media_kit/lib/src/libmpv/player.dart
+++ b/media_kit/lib/src/libmpv/player.dart
@@ -92,8 +92,10 @@ class Player extends PlatformPlayer {
 
       // On Android, calling `quit 0` does not actually clean the resources.
       // We must call `mpv_destroy()` in order to prevent extremely high CPU usage.
-      // This should also be useful for other platforms.
-      _libmpv?.mpv_destroy(ctx);
+      // This can cause crashes on other platforms, so we run it on Android only - where it is necessary.
+      if(Platform.isAndroid){
+        _libmpv?.mpv_destroy(ctx);
+      }
 
       super.dispose();
     }

--- a/media_kit/lib/src/libmpv/player.dart
+++ b/media_kit/lib/src/libmpv/player.dart
@@ -90,12 +90,10 @@ class Player extends PlatformPlayer {
       // If timed out, don't do anything. Perhaps implement a solution to handle this in the future.
       await _mpvShutdownComplete.future.timeout(Duration(seconds: 3), onTimeout: () {});
 
-      // On android, calling `quit 0` does not actually clean the resources.
+      // On Android, calling `quit 0` does not actually clean the resources.
       // We must call `mpv_destroy()` in order to prevent extremely high CPU usage.
-      // In the future, find out whether other platforms require this as well.
-      if(Platform.isAndroid){
-        _libmpv?.mpv_destroy(ctx);
-      }
+      // This should also be useful for other platforms.
+      _libmpv?.mpv_destroy(ctx);
 
       super.dispose();
     }


### PR DESCRIPTION
When the `Player::dispose` function is called, the `mpv` instance shutdown is induced via `mpv_command_string` with the command `quit 0`.

On android, `quit 0` does not actually clean some resources (a thread is left active, consuming high CPU). `mpv_destroy` must be called for actual cleaning to happen.

When the player is shut down, a `MPV_EVENT_SHUTDOWN` event is emitted to the event loop, causing it to quit.
In this PR, we simply call `mpv_destroy` on Android devices.

We also wait for `MPV_EVENT_SHUTDOWN` to be emitted before finishing disposing.

I reproduced and tested it out by having an android app display a video and then unload it, over and over again.

It must be noted that after 100+ times, cpu usage becomes high again, and new videos stop loading in time. Maybe somewhere else is leaking? Perhaps a problem in mpv itself? It should be investigated.
