### PR TITLE
feat: expose vo & hwdec in VideoControllerConfiguration

### DIFF
--- a/media_kit/CHANGELOG.md
+++ b/media_kit/CHANGELOG.md
@@ -6,6 +6,7 @@
   - feat: `InitializerIsolate.dispose`
   - feat: `InitializerNativeEventLoop.dispose`
 - feat: `PlatformPlayer.waitForVideoControllerInitializationIfAttached`
+- feat: HTTP headers support in `Media`
 
 ## 0.0.7+1
 

--- a/media_kit_test/ios/Podfile.lock
+++ b/media_kit_test/ios/Podfile.lock
@@ -54,7 +54,7 @@ DEPENDENCIES:
   - media_kit_libs_ios_video (from `.symlinks/plugins/media_kit_libs_ios_video/ios`)
   - media_kit_native_event_loop (from `.symlinks/plugins/media_kit_native_event_loop/ios`)
   - media_kit_video (from `.symlinks/plugins/media_kit_video/ios`)
-  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
 
 SPEC REPOS:
   trunk:
@@ -75,7 +75,7 @@ EXTERNAL SOURCES:
   media_kit_video:
     :path: ".symlinks/plugins/media_kit_video/ios"
   path_provider_foundation:
-    :path: ".symlinks/plugins/path_provider_foundation/ios"
+    :path: ".symlinks/plugins/path_provider_foundation/darwin"
 
 SPEC CHECKSUMS:
   DKImagePickerController: b512c28220a2b8ac7419f21c491fc8534b7601ac
@@ -85,7 +85,7 @@ SPEC CHECKSUMS:
   media_kit_libs_ios_video: 96259eccffaa309b63a7ee610c2c7786a3b335e5
   media_kit_native_event_loop: 9f9eb778d0d806ab9486eff7513f7f90f07d50f8
   media_kit_video: c6ae801433b484912087b519b45f1beac97b960b
-  path_provider_foundation: c68054786f1b4f3343858c1e1d0caaded73f0be9
+  path_provider_foundation: eaf5b3e458fc0e5fbb9940fb09980e853fe058b8
   SDWebImage: fd7e1a22f00303e058058278639bf6196ee431fe
   SwiftyGif: 93a1cc87bf3a51916001cf8f3d63835fb64c819f
 

--- a/media_kit_test/ios/Runner.xcodeproj/project.pbxproj
+++ b/media_kit_test/ios/Runner.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (

--- a/media_kit_test/lib/common/globals.dart
+++ b/media_kit_test/lib/common/globals.dart
@@ -1,3 +1,6 @@
 import 'package:flutter/foundation.dart';
+import 'package:media_kit_video/media_kit_video.dart';
 
-final enableHardwareAcceleration = ValueNotifier<bool>(true);
+final configuration = ValueNotifier<VideoControllerConfiguration>(
+  const VideoControllerConfiguration(enableHardwareAcceleration: true),
+);

--- a/media_kit_test/lib/main.dart
+++ b/media_kit_test/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';
-import 'package:media_kit_test/common/globals.dart';
+import 'package:media_kit_video/media_kit_video.dart';
 
 import 'tests/01.single_player_single_video.dart';
 import 'tests/02.single_player_multiple_video.dart';
@@ -10,6 +10,7 @@ import 'tests/05.stress_test.dart';
 import 'tests/06.paint_first_frame.dart';
 import 'tests/07.video_controller_set_size.dart';
 
+import 'common/globals.dart';
 import 'common/sources/sources.dart';
 
 Future<void> main() async {
@@ -52,15 +53,16 @@ class PrimaryScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('package:media_kit'),
         actions: [
-          ValueListenableBuilder<bool>(
-            valueListenable: enableHardwareAcceleration,
+          ValueListenableBuilder<VideoControllerConfiguration>(
+            valueListenable: configuration,
             builder: (context, value, _) => TextButton(
               onPressed: () {
-                enableHardwareAcceleration.value =
-                    !enableHardwareAcceleration.value;
+                configuration.value = VideoControllerConfiguration(
+                  enableHardwareAcceleration: !value.enableHardwareAcceleration,
+                );
               },
               child: Text(
-                value ? 'H/W' : 'S/W',
+                value.enableHardwareAcceleration ? 'H/W' : 'S/W',
                 style: const TextStyle(
                   color: Colors.white,
                 ),

--- a/media_kit_test/lib/tests/01.single_player_single_video.dart
+++ b/media_kit_test/lib/tests/01.single_player_single_video.dart
@@ -21,7 +21,7 @@ class _SinglePlayerSingleVideoScreenState
   late final Player player = Player();
   late final VideoController controller = VideoController(
     player,
-    enableHardwareAcceleration: enableHardwareAcceleration.value,
+    configuration: configuration.value,
   );
 
   @override

--- a/media_kit_test/lib/tests/02.single_player_multiple_video.dart
+++ b/media_kit_test/lib/tests/02.single_player_multiple_video.dart
@@ -23,11 +23,11 @@ class _SinglePlayerMultipleVideoScreenState
   //       Here, two [VideoController]s are created for testing.
   late final VideoController controller0 = VideoController(
     player,
-    enableHardwareAcceleration: enableHardwareAcceleration.value,
+    configuration: configuration.value,
   );
   late final VideoController controller1 = VideoController(
     player,
-    enableHardwareAcceleration: enableHardwareAcceleration.value,
+    configuration: configuration.value,
   );
 
   @override

--- a/media_kit_test/lib/tests/03.multiple_player_multiple_video.dart
+++ b/media_kit_test/lib/tests/03.multiple_player_multiple_video.dart
@@ -24,11 +24,11 @@ class _MultiplePlayerMultipleVideoScreenState
   late final List<VideoController> controllers = [
     VideoController(
       players[0],
-      enableHardwareAcceleration: enableHardwareAcceleration.value,
+      configuration: configuration.value,
     ),
     VideoController(
       players[1],
-      enableHardwareAcceleration: enableHardwareAcceleration.value,
+      configuration: configuration.value,
     ),
   ];
 

--- a/media_kit_test/lib/tests/04.tabs_test.dart
+++ b/media_kit_test/lib/tests/04.tabs_test.dart
@@ -57,7 +57,7 @@ class TabViewState extends State<TabView> {
   late final Player player = Player();
   late final VideoController controller = VideoController(
     player,
-    enableHardwareAcceleration: enableHardwareAcceleration.value,
+    configuration: configuration.value,
   );
 
   @override

--- a/media_kit_test/lib/tests/05.stress_test.dart
+++ b/media_kit_test/lib/tests/05.stress_test.dart
@@ -26,7 +26,7 @@ class _StressTestScreenState extends State<StressTestScreen> {
       final player = Player();
       final controller = VideoController(
         player,
-        enableHardwareAcceleration: enableHardwareAcceleration.value,
+        configuration: configuration.value,
       );
       players.add(player);
       controllers.add(controller);

--- a/media_kit_test/lib/tests/06.paint_first_frame.dart
+++ b/media_kit_test/lib/tests/06.paint_first_frame.dart
@@ -18,23 +18,23 @@ Future<void> paintFirstFrame(BuildContext context) async {
   final controllers = [
     VideoController(
       players[0],
-      enableHardwareAcceleration: enableHardwareAcceleration.value,
+      configuration: configuration.value,
     ),
     VideoController(
       players[1],
-      enableHardwareAcceleration: enableHardwareAcceleration.value,
+      configuration: configuration.value,
     ),
     VideoController(
       players[2],
-      enableHardwareAcceleration: enableHardwareAcceleration.value,
+      configuration: configuration.value,
     ),
     VideoController(
       players[3],
-      enableHardwareAcceleration: enableHardwareAcceleration.value,
+      configuration: configuration.value,
     ),
     VideoController(
       players[4],
-      enableHardwareAcceleration: enableHardwareAcceleration.value,
+      configuration: configuration.value,
     ),
   ];
 

--- a/media_kit_test/lib/tests/07.video_controller_set_size.dart
+++ b/media_kit_test/lib/tests/07.video_controller_set_size.dart
@@ -18,7 +18,7 @@ class _VideoControllerSetSizeScreenState
   late final Player player = Player();
   late final VideoController controller = VideoController(
     player,
-    enableHardwareAcceleration: enableHardwareAcceleration.value,
+    configuration: configuration.value,
   );
 
   @override

--- a/media_kit_test/macos/Podfile.lock
+++ b/media_kit_test/macos/Podfile.lock
@@ -15,7 +15,7 @@ DEPENDENCIES:
   - media_kit_libs_macos_video (from `Flutter/ephemeral/.symlinks/plugins/media_kit_libs_macos_video/macos`)
   - media_kit_native_event_loop (from `Flutter/ephemeral/.symlinks/plugins/media_kit_native_event_loop/macos`)
   - media_kit_video (from `Flutter/ephemeral/.symlinks/plugins/media_kit_video/macos`)
-  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/macos`)
+  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
 
 EXTERNAL SOURCES:
   FlutterMacOS:
@@ -27,14 +27,14 @@ EXTERNAL SOURCES:
   media_kit_video:
     :path: Flutter/ephemeral/.symlinks/plugins/media_kit_video/macos
   path_provider_foundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/macos
+    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
 
 SPEC CHECKSUMS:
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   media_kit_libs_macos_video: 0a4a5bf21533cba968c0833f1b59e9af8b5847f1
   media_kit_native_event_loop: 6cf347b98de9735713a86c188467a008af5f860e
   media_kit_video: 1e311a3dfe41f276935f95518b51a0c3ff72114f
-  path_provider_foundation: c68054786f1b4f3343858c1e1d0caaded73f0be9
+  path_provider_foundation: eaf5b3e458fc0e5fbb9940fb09980e853fe058b8
 
 PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7
 

--- a/media_kit_video/CHANGELOG.md
+++ b/media_kit_video/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.0.10
 
+- feat: `VideoControllerConfiguration`
 - feat: `VideoController.waitUntilFirstFrameRendered`
 - refactor: clean-up package structure
 - refactor: remove `VideoController.dispose`

--- a/media_kit_video/common/darwin/Classes/plugin/MediaKitVideoPlugin.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/MediaKitVideoPlugin.swift
@@ -59,22 +59,15 @@ public class MediaKitVideoPlugin: NSObject, FlutterPlugin {
   ) {
     let args = arguments as? [String: Any]
     let handleStr = args?["handle"] as! String
-    let widthStr = args?["width"] as! String
-    let heightStr = args?["height"] as! String
-    let enableHardwareAcceleration =
-      args?["enableHardwareAcceleration"] as! Bool
-
     let handle: Int64? = Int64(handleStr)
-    let width: Int64? = Int64(widthStr)
-    let height: Int64? = Int64(heightStr)
+    let configDict = args?["configuration"] as! [String: Any]
+    let configuration = VideoOutputConfiguration.fromDict(configDict)
 
     assert(handle != nil, "handle must be an Int64")
 
     videoOutputManager.create(
       handle: handle!,
-      width: width,
-      height: height,
-      enableHardwareAcceleration: enableHardwareAcceleration,
+      configuration: configuration,
       textureUpdateCallback: { (_ textureId: Int64, _ size: CGSize) in
         self.channel.invokeMethod(
           "VideoOutput.Resize",

--- a/media_kit_video/common/darwin/Classes/plugin/TextureSW.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/TextureSW.swift
@@ -44,9 +44,6 @@ public class TextureSW: NSObject, FlutterTexture, ResizableTextureProtocol {
   }
 
   private func initMPV() {
-    MPVHelpers.checkError(mpv_set_option_string(handle, "vo", "libmpv"))
-    MPVHelpers.checkError(mpv_set_option_string(handle, "hwdec", "auto"))
-
     let api = UnsafeMutableRawPointer(
       mutating: (MPV_RENDER_API_TYPE_SW as NSString).utf8String
     )

--- a/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
@@ -38,9 +38,7 @@ public class VideoOutput: NSObject {
 
   init(
     handle: Int64,
-    width: Int64?,
-    height: Int64?,
-    enableHardwareAcceleration: Bool,
+    configuration: VideoOutputConfiguration,
     registry: FlutterTextureRegistry,
     textureUpdateCallback: @escaping TextureUpdateCallback
   ) {
@@ -48,9 +46,9 @@ public class VideoOutput: NSObject {
     assert(handle != nil, "handle casting")
 
     self.handle = handle!
-    self.width = width
-    self.height = height
-    self.enableHardwareAcceleration = enableHardwareAcceleration
+    self.width = configuration.width
+    self.height = configuration.height
+    self.enableHardwareAcceleration = configuration.enableHardwareAcceleration
     self.registry = registry
     self.textureUpdateCallback = textureUpdateCallback
 

--- a/media_kit_video/common/darwin/Classes/plugin/VideoOutputConfiguration.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/VideoOutputConfiguration.swift
@@ -1,0 +1,33 @@
+public class VideoOutputConfiguration {
+  public let width: Int64?
+  public let height: Int64?
+  public let enableHardwareAcceleration: Bool
+
+  init(
+    width: Int64?,
+    height: Int64?,
+    enableHardwareAcceleration: Bool
+  ) {
+    self.width = width
+    self.height = height
+    self.enableHardwareAcceleration = enableHardwareAcceleration
+  }
+
+  public static func fromDict(_ dict: [String: Any])
+    -> VideoOutputConfiguration
+  {
+    let widthStr = dict["width"] as! String
+    let heightStr = dict["height"] as! String
+    let enableHardwareAcceleration =
+      dict["enableHardwareAcceleration"] as! Bool
+
+    let width: Int64? = Int64(widthStr)
+    let height: Int64? = Int64(heightStr)
+
+    return VideoOutputConfiguration(
+      width: width,
+      height: height,
+      enableHardwareAcceleration: enableHardwareAcceleration
+    )
+  }
+}

--- a/media_kit_video/common/darwin/Classes/plugin/VideoOutputManager.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/VideoOutputManager.swift
@@ -14,16 +14,12 @@ public class VideoOutputManager: NSObject {
 
   public func create(
     handle: Int64,
-    width: Int64?,
-    height: Int64?,
-    enableHardwareAcceleration: Bool,
+    configuration: VideoOutputConfiguration,
     textureUpdateCallback: @escaping VideoOutput.TextureUpdateCallback
   ) {
     let videoOutput = VideoOutput(
       handle: handle,
-      width: width,
-      height: height,
-      enableHardwareAcceleration: enableHardwareAcceleration,
+      configuration: configuration,
       registry: self.registry,
       textureUpdateCallback: textureUpdateCallback
     )

--- a/media_kit_video/ios/Classes/plugin/TextureHW.swift
+++ b/media_kit_video/ios/Classes/plugin/TextureHW.swift
@@ -56,9 +56,6 @@ public class TextureHW: NSObject, FlutterTexture, ResizableTextureProtocol {
       EAGLContext.setCurrent(nil)
     }
 
-    MPVHelpers.checkError(mpv_set_option_string(handle, "vo", "libmpv"))
-    MPVHelpers.checkError(mpv_set_option_string(handle, "hwdec", "auto"))
-
     let api = UnsafeMutableRawPointer(
       mutating: (MPV_RENDER_API_TYPE_OPENGL as NSString).utf8String
     )

--- a/media_kit_video/ios/Classes/plugin/common/VideoOutputConfiguration.swift
+++ b/media_kit_video/ios/Classes/plugin/common/VideoOutputConfiguration.swift
@@ -1,0 +1,1 @@
+../../../../common/darwin/Classes/plugin/VideoOutputConfiguration.swift

--- a/media_kit_video/lib/src/video_controller/android_video_controller/real.dart
+++ b/media_kit_video/lib/src/video_controller/android_video_controller/real.dart
@@ -37,12 +37,15 @@ class AndroidVideoController extends PlatformVideoController {
   /// Whether [AndroidVideoController] is supported on the current platform or not.
   static bool get supported => Platform.isAndroid;
 
+  /// Fixed width of the video output.
+  int? width;
+
+  /// Fixed height of the video output.
+  int? height;
+
   /// {@macro android_video_controller}
   AndroidVideoController._(
     super.player,
-    super.width,
-    super.height,
-    super.enableHardwareAcceleration,
     super.configuration,
   ) {
     // Notify about the first frame being rendered.
@@ -131,7 +134,6 @@ class AndroidVideoController extends PlatformVideoController {
   /// {@macro android_video_controller}
   static Future<PlatformVideoController> create(
     Player player,
-    bool enableHardwareAcceleration,
     VideoControllerConfiguration configuration,
   ) async {
     // Retrieve the native handle of the [Player].
@@ -140,6 +142,8 @@ class AndroidVideoController extends PlatformVideoController {
     if (_controllers.containsKey(handle)) {
       return _controllers[handle]!;
     }
+
+    bool enableHardwareAcceleration = configuration.enableHardwareAcceleration;
 
     // Enforce software rendering in emulators.
     final bool isEmulator = await _channel.invokeMethod('Utils.IsEmulator');
@@ -152,9 +156,6 @@ class AndroidVideoController extends PlatformVideoController {
     // Creation:
     final controller = AndroidVideoController._(
       player,
-      null,
-      null,
-      enableHardwareAcceleration,
       configuration,
     );
     // Register [_dispose] for execution upon [Player.dispose].

--- a/media_kit_video/lib/src/video_controller/android_video_controller/real.dart
+++ b/media_kit_video/lib/src/video_controller/android_video_controller/real.dart
@@ -100,7 +100,8 @@ class AndroidVideoController extends PlatformVideoController {
           Pointer.fromAddress(handle),
           property.cast(),
         );
-        if (property.toDartString() == 'gpu') {
+        debugPrint(vo.cast<Utf8>().toDartString());
+        if (vo.cast<Utf8>().toDartString() == 'gpu') {
           // NOTE: Only required for --vo=gpu
           // With --vo=gpu, we need to update the `android.graphics.SurfaceTexture` size & notify libmpv to re-create vo.
           // In native Android, this kind of rendering is done with `android.view.SurfaceView` + `android.view.SurfaceHolder`, which offers `onSurfaceChanged` callback to handle this
@@ -178,7 +179,7 @@ class AndroidVideoController extends PlatformVideoController {
     NativeLibrary.ensureInitialized();
     final mpv = MPV(DynamicLibrary.open(NativeLibrary.path));
 
-    final values = configuration.vo == null && configuration.hwdec == null
+    final values = configuration.vo == null || configuration.hwdec == null
         ? enableHardwareAcceleration
             ? {
                 // H/W decoding & rendering with --vo=gpu + --hwdec=mediacodec-copy.

--- a/media_kit_video/lib/src/video_controller/android_video_controller/stub.dart
+++ b/media_kit_video/lib/src/video_controller/android_video_controller/stub.dart
@@ -5,6 +5,7 @@
 /// Use of this source code is governed by MIT license that can be found in the LICENSE file.
 import 'package:media_kit/media_kit.dart';
 
+import 'package:media_kit_video/src/video_controller/video_controller.dart';
 import 'package:media_kit_video/src/video_controller/platform_video_controller.dart';
 
 // Stub declaration for avoiding compilation errors on Dart JS using conditional imports.
@@ -14,16 +15,12 @@ class AndroidVideoController extends PlatformVideoController {
 
   AndroidVideoController._(
     super.player,
-    super.width,
-    super.height,
-    super.enableHardwareAcceleration,
     super.configuration,
   );
 
   static Future<PlatformVideoController> create(
     Player player,
-    bool enableHardwareAcceleration,
-    PlayerConfiguration configuration,
+    VideoControllerConfiguration configuration,
   ) =>
       throw UnimplementedError();
 

--- a/media_kit_video/lib/src/video_controller/android_video_controller/stub.dart
+++ b/media_kit_video/lib/src/video_controller/android_video_controller/stub.dart
@@ -17,11 +17,13 @@ class AndroidVideoController extends PlatformVideoController {
     super.width,
     super.height,
     super.enableHardwareAcceleration,
+    super.configuration,
   );
 
   static Future<PlatformVideoController> create(
     Player player,
     bool enableHardwareAcceleration,
+    PlayerConfiguration configuration,
   ) =>
       throw UnimplementedError();
 

--- a/media_kit_video/lib/src/video_controller/native_video_controller/real.dart
+++ b/media_kit_video/lib/src/video_controller/native_video_controller/real.dart
@@ -115,9 +115,12 @@ class NativeVideoController extends PlatformVideoController {
       'VideoOutputManager.Create',
       {
         'handle': handle.toString(),
-        'width': configuration.width.toString(),
-        'height': configuration.height.toString(),
-        'enableHardwareAcceleration': configuration.enableHardwareAcceleration,
+        'configuration': {
+          'width': configuration.width.toString(),
+          'height': configuration.height.toString(),
+          'enableHardwareAcceleration':
+              configuration.enableHardwareAcceleration,
+        },
       },
     );
 

--- a/media_kit_video/lib/src/video_controller/native_video_controller/real.dart
+++ b/media_kit_video/lib/src/video_controller/native_video_controller/real.dart
@@ -39,21 +39,21 @@ class NativeVideoController extends PlatformVideoController {
       Platform.isMacOS ||
       Platform.isIOS;
 
+  /// Fixed width of the video output.
+  int? width;
+
+  /// Fixed height of the video output.
+  int? height;
+
   /// {@macro native_video_controller}
   NativeVideoController._(
     super.player,
-    super.width,
-    super.height,
-    super.enableHardwareAcceleration,
     super.configuration,
   );
 
   /// {@macro native_video_controller}
   static Future<PlatformVideoController> create(
     Player player,
-    int? width,
-    int? height,
-    bool enableHardwareAcceleration,
     VideoControllerConfiguration configuration,
   ) async {
     // Retrieve the native handle of the [Player].
@@ -66,11 +66,11 @@ class NativeVideoController extends PlatformVideoController {
     // Creation:
     final controller = NativeVideoController._(
       player,
-      width,
-      height,
-      enableHardwareAcceleration,
       configuration,
     );
+
+    controller.width = configuration.width;
+    controller.height = configuration.height;
 
     // ----------------------------------------------
     NativeLibrary.ensureInitialized();
@@ -115,9 +115,9 @@ class NativeVideoController extends PlatformVideoController {
       'VideoOutputManager.Create',
       {
         'handle': handle.toString(),
-        'width': width.toString(),
-        'height': height.toString(),
-        'enableHardwareAcceleration': enableHardwareAcceleration,
+        'width': configuration.width.toString(),
+        'height': configuration.height.toString(),
+        'enableHardwareAcceleration': configuration.enableHardwareAcceleration,
       },
     );
 
@@ -169,7 +169,7 @@ class NativeVideoController extends PlatformVideoController {
   }
 
   /// Currently created [NativeVideoController]s.
-  /// This is used to notify about updated texture IDs & [Rect]s through [channel].
+  /// This is used to notify about updated texture IDs & [Rect]s through [_channel].
   static final _controllers = HashMap<int, NativeVideoController>();
 
   /// [MethodChannel] for invoking platform specific native implementation.

--- a/media_kit_video/lib/src/video_controller/native_video_controller/stub.dart
+++ b/media_kit_video/lib/src/video_controller/native_video_controller/stub.dart
@@ -17,6 +17,7 @@ class NativeVideoController extends PlatformVideoController {
     super.width,
     super.height,
     super.enableHardwareAcceleration,
+    super.configuration,
   );
 
   static Future<PlatformVideoController> create(
@@ -24,6 +25,7 @@ class NativeVideoController extends PlatformVideoController {
     int? width,
     int? height,
     bool enableHardwareAcceleration,
+    PlayerConfiguration configuration,
   ) =>
       throw UnimplementedError();
 

--- a/media_kit_video/lib/src/video_controller/native_video_controller/stub.dart
+++ b/media_kit_video/lib/src/video_controller/native_video_controller/stub.dart
@@ -5,6 +5,7 @@
 /// Use of this source code is governed by MIT license that can be found in the LICENSE file.
 import 'package:media_kit/media_kit.dart';
 
+import 'package:media_kit_video/src/video_controller/video_controller.dart';
 import 'package:media_kit_video/src/video_controller/platform_video_controller.dart';
 
 // Stub declaration for avoiding compilation errors on Dart JS using conditional imports.
@@ -14,18 +15,12 @@ class NativeVideoController extends PlatformVideoController {
 
   NativeVideoController._(
     super.player,
-    super.width,
-    super.height,
-    super.enableHardwareAcceleration,
     super.configuration,
   );
 
   static Future<PlatformVideoController> create(
     Player player,
-    int? width,
-    int? height,
-    bool enableHardwareAcceleration,
-    PlayerConfiguration configuration,
+    VideoControllerConfiguration configuration,
   ) =>
       throw UnimplementedError();
 

--- a/media_kit_video/lib/src/video_controller/platform_video_controller.dart
+++ b/media_kit_video/lib/src/video_controller/platform_video_controller.dart
@@ -5,7 +5,10 @@
 /// Use of this source code is governed by MIT license that can be found in the LICENSE file.
 import 'dart:async';
 import 'package:flutter/widgets.dart';
+
 import 'package:media_kit/media_kit.dart';
+
+import 'package:media_kit_video/src/video_controller/video_controller.dart';
 
 /// {@template platform_video_controller}
 ///
@@ -31,6 +34,9 @@ abstract class PlatformVideoController {
   /// Whether hardware acceleration should be enabled or not.
   final bool enableHardwareAcceleration;
 
+  /// User defined configuration for [VideoController].
+  final VideoControllerConfiguration configuration;
+
   /// Texture ID of the video output, registered with Flutter engine by the native implementation.
   final ValueNotifier<int?> id = ValueNotifier<int?>(null);
 
@@ -43,6 +49,7 @@ abstract class PlatformVideoController {
     this.width,
     this.height,
     this.enableHardwareAcceleration,
+    this.configuration,
   );
 
   /// Sets the required size of the video output.

--- a/media_kit_video/lib/src/video_controller/platform_video_controller.dart
+++ b/media_kit_video/lib/src/video_controller/platform_video_controller.dart
@@ -25,15 +25,6 @@ abstract class PlatformVideoController {
   /// The [Player] instance associated with this instance.
   final Player player;
 
-  /// Fixed width of the video output.
-  int? width;
-
-  /// Fixed height of the video output.
-  int? height;
-
-  /// Whether hardware acceleration should be enabled or not.
-  final bool enableHardwareAcceleration;
-
   /// User defined configuration for [VideoController].
   final VideoControllerConfiguration configuration;
 
@@ -46,9 +37,6 @@ abstract class PlatformVideoController {
   /// {@macro platform_video_controller}
   PlatformVideoController(
     this.player,
-    this.width,
-    this.height,
-    this.enableHardwareAcceleration,
     this.configuration,
   );
 
@@ -62,16 +50,6 @@ abstract class PlatformVideoController {
     int? width,
     int? height,
   });
-
-  @override
-  String toString() => 'VideoController('
-      'player: $player, '
-      'width: $width, '
-      'height: $height, '
-      'enableHardwareAcceleration: $enableHardwareAcceleration, '
-      'id: $id, '
-      'rect: $rect'
-      ')';
 
   /// A [Future] that completes when the first video frame has been rendered.
   Future<void> get waitUntilFirstFrameRendered =>

--- a/media_kit_video/lib/src/video_controller/video_controller.dart
+++ b/media_kit_video/lib/src/video_controller/video_controller.dart
@@ -22,22 +22,32 @@ import 'package:media_kit_video/src/video_controller/web_video_controller/web_vi
 /// [VideoController] is used to initialize & display video output.
 /// It takes reference to existing [Player] instance from `package:media_kit`.
 ///
+/// Passing [VideoController] to [Video] widget will cause the video output to be displayed.
+///
 /// ```dart
 /// late final player = Player();
 /// late final controller = VideoController(player);
 /// ```
 ///
-/// **Notes:**
+/// **Configurable options:**
 ///
-/// 1. You can limit size of the video output by specifying [width] & [height].
-///    * By default, both [height] & [width] are `null` i.e. output is based on video's resolution.
+/// 1. You can limit size of the video output by specifying [VideoControllerConfiguration.width] & [VideoControllerConfiguration.height].
+///    * A smaller width & height may yield substantial performance improvements.
+///    * By default, both [VideoControllerConfiguration.height] & [VideoControllerConfiguration.width] are `null` i.e. output is based on video's resolution.
 /// 2. You can switch between GPU & CPU rendering by specifying `enableHardwareAcceleration`.
-///    * By default, [enableHardwareAcceleration] is `true` i.e. GPU (Direct3D/OpenGL/METAL) is utilized.
+///    * Disabling the option may improve stability on certain devices.
+///    * By default, [VideoControllerConfiguration.enableHardwareAcceleration] is `true` i.e. GPU (Direct3D/OpenGL/METAL) is utilized.
 ///
 /// **Platform specific differences:**
 ///
-/// 1. [width] & [height] arguments have no effect on Android & Flutter Web.
-/// 2. The [enableHardwareAcceleration] argument is ignored on Flutter Web i.e. GPU usage is dependent on the client's web browser.
+/// **Android**
+/// * [VideoControllerConfiguration.width] & [VideoControllerConfiguration.height] arguments have no effect.
+///
+/// **Web**
+/// * [VideoControllerConfiguration.width] & [VideoControllerConfiguration.height] arguments have no effect.
+/// * Only single [Video] can be displayed at a time for a single [VideoController].
+///   Displaying [Video] widgets with same[VideoController]  will cause only last [Video] to be displayed.
+/// * [VideoControllerConfiguration.enableHardwareAcceleration] is ignored i.e. GPU usage is dependent on the client's web browser.
 ///
 /// {@endtemplate}
 class VideoController {
@@ -56,9 +66,6 @@ class VideoController {
   /// {@macro platform_video_controller}
   VideoController(
     Player player, {
-    int? width,
-    int? height,
-    bool enableHardwareAcceleration = true,
     VideoControllerConfiguration configuration =
         const VideoControllerConfiguration(),
   }) {
@@ -71,9 +78,6 @@ class VideoController {
         } else if (NativeVideoController.supported) {
           final result = await NativeVideoController.create(
             player,
-            width,
-            height,
-            enableHardwareAcceleration,
             configuration,
           );
           platform.complete(result);
@@ -81,7 +85,6 @@ class VideoController {
         } else if (AndroidVideoController.supported) {
           final result = await AndroidVideoController.create(
             player,
-            enableHardwareAcceleration,
             configuration,
           );
           platform.complete(result);
@@ -166,9 +169,27 @@ class VideoControllerConfiguration {
   /// * Android: `mediacodec-copy`
   final String? hwdec;
 
+  /// The fixed width of the [Video] output.
+  ///
+  /// Default: `null`
+  final int? width;
+
+  /// The fixed height of the [Video] output.
+  ///
+  /// Default: `null`
+  final int? height;
+
+  /// Whether to enable hardware acceleration.
+  ///
+  /// Default: `true`
+  final bool enableHardwareAcceleration;
+
   /// {@macro video_controller_configuration}
   const VideoControllerConfiguration({
     this.vo,
     this.hwdec,
+    this.width,
+    this.height,
+    this.enableHardwareAcceleration = true,
   });
 }

--- a/media_kit_video/lib/src/video_controller/video_controller.dart
+++ b/media_kit_video/lib/src/video_controller/video_controller.dart
@@ -59,6 +59,8 @@ class VideoController {
     int? width,
     int? height,
     bool enableHardwareAcceleration = true,
+    VideoControllerConfiguration configuration =
+        const VideoControllerConfiguration(),
   }) {
     player.platform?.isVideoControllerAttached = true;
 
@@ -72,6 +74,7 @@ class VideoController {
             width,
             height,
             enableHardwareAcceleration,
+            configuration,
           );
           platform.complete(result);
           notifier.value = result;
@@ -79,6 +82,7 @@ class VideoController {
           final result = await AndroidVideoController.create(
             player,
             enableHardwareAcceleration,
+            configuration,
           );
           platform.complete(result);
           notifier.value = result;
@@ -138,4 +142,33 @@ class VideoController {
     final instance = await platform.future;
     return instance.waitUntilFirstFrameRendered;
   }
+}
+
+/// {@template video_controller_configuration}
+///
+/// VideoControllerConfiguration
+/// ----------------------------
+/// Configurable options for customizing the [VideoController] behavior.
+///
+/// {@endtemplate}
+class VideoControllerConfiguration {
+  /// Sets the [`--vo`](https://mpv.io/manual/stable/#options-vo) property on libmpv backend.
+  ///
+  /// Default: Platform specific.
+  /// * Windows, GNU/Linux, macOS & iOS: `libmpv`
+  /// * Android: `gpu`
+  final String? vo;
+
+  /// Sets the [`--hwdec`](https://mpv.io/manual/stable/#options-hwdec) property on libmpv backend.
+  ///
+  /// Default: Platform specific.
+  /// * Windows, GNU/Linux, macOS & iOS : `auto`
+  /// * Android: `mediacodec-copy`
+  final String? hwdec;
+
+  /// {@macro video_controller_configuration}
+  const VideoControllerConfiguration({
+    this.vo,
+    this.hwdec,
+  });
 }

--- a/media_kit_video/lib/src/video_controller/web_video_controller/real.dart
+++ b/media_kit_video/lib/src/video_controller/web_video_controller/real.dart
@@ -7,11 +7,13 @@
 import 'dart:async';
 import 'dart:js' as js;
 import 'dart:html' as html;
+
 import 'dart_ui/dart_ui.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/foundation.dart';
 import 'package:media_kit/media_kit.dart';
 
+import 'package:media_kit_video/src/video_controller/video_controller.dart';
 import 'package:media_kit_video/src/video_controller/platform_video_controller.dart';
 
 /// {@template web_video_controller}
@@ -32,10 +34,14 @@ class WebVideoController extends PlatformVideoController {
     super.width,
     super.height,
     super.enableHardwareAcceleration,
+    super.configuration,
   );
 
   /// {@macro web_video_controller}
-  static Future<PlatformVideoController> create(Player player) async {
+  static Future<PlatformVideoController> create(
+    Player player,
+    VideoControllerConfiguration configuration,
+  ) async {
     // Retrieve the native handle of the [Player].
     final handle = await player.handle;
 
@@ -44,6 +50,7 @@ class WebVideoController extends PlatformVideoController {
       null,
       null,
       true,
+      configuration,
     );
     // Register [_dispose] for execution upon [Player.dispose].
     player.platform?.release.add(controller._dispose);

--- a/media_kit_video/lib/src/video_controller/web_video_controller/real.dart
+++ b/media_kit_video/lib/src/video_controller/web_video_controller/real.dart
@@ -31,9 +31,6 @@ class WebVideoController extends PlatformVideoController {
   /// {@macro web_video_controller}
   WebVideoController._(
     super.player,
-    super.width,
-    super.height,
-    super.enableHardwareAcceleration,
     super.configuration,
   );
 
@@ -47,9 +44,6 @@ class WebVideoController extends PlatformVideoController {
 
     final controller = WebVideoController._(
       player,
-      null,
-      null,
-      true,
       configuration,
     );
     // Register [_dispose] for execution upon [Player.dispose].

--- a/media_kit_video/lib/src/video_controller/web_video_controller/stub.dart
+++ b/media_kit_video/lib/src/video_controller/web_video_controller/stub.dart
@@ -5,6 +5,7 @@
 /// Use of this source code is governed by MIT license that can be found in the LICENSE file.
 import 'package:media_kit/media_kit.dart';
 
+import 'package:media_kit_video/src/video_controller/video_controller.dart';
 import 'package:media_kit_video/src/video_controller/platform_video_controller.dart';
 
 // Stub declaration for avoiding compilation errors on Dart Native using conditional imports.
@@ -17,10 +18,12 @@ class WebVideoController extends PlatformVideoController {
     super.width,
     super.height,
     super.enableHardwareAcceleration,
+    super.configuration,
   );
 
   static Future<PlatformVideoController> create(
     Player player,
+    VideoControllerConfiguration configuration,
   ) =>
       throw UnimplementedError();
 

--- a/media_kit_video/lib/src/video_controller/web_video_controller/stub.dart
+++ b/media_kit_video/lib/src/video_controller/web_video_controller/stub.dart
@@ -15,9 +15,6 @@ class WebVideoController extends PlatformVideoController {
 
   WebVideoController._(
     super.player,
-    super.width,
-    super.height,
-    super.enableHardwareAcceleration,
     super.configuration,
   );
 

--- a/media_kit_video/linux/include/media_kit_video/video_output.h
+++ b/media_kit_video/linux/include/media_kit_video/video_output.h
@@ -15,6 +15,19 @@
 #include <mpv/render.h>
 #include <mpv/render_gl.h>
 
+typedef struct _VideoOutputConfiguration {
+  gint64 width;
+  gint64 height;
+  bool enable_hardware_acceleration;
+
+  _VideoOutputConfiguration(gint64 width = NULL,
+                            gint64 height = NULL,
+                            bool enable_hardware_acceleration = true)
+      : width(width),
+        height(height),
+        enable_hardware_acceleration(enable_hardware_acceleration) {}
+} VideoOutputConfiguration;
+
 // Callback invoked when the texture ID updates i.e. video dimensions changes.
 typedef void (*TextureUpdateCallback)(gint64 id,
                                       gint64 width,
@@ -47,9 +60,7 @@ G_DECLARE_FINAL_TYPE(VideoOutput,
 VideoOutput* video_output_new(FlTextureRegistrar* texture_registrar,
                               FlView* view,
                               gint64 handle,
-                              gint64 width,
-                              gint64 height,
-                              gboolean enable_hardware_acceleration);
+                              VideoOutputConfiguration configuration);
 
 /**
  * @brief Sets the callback invoked when the texture ID updates i.e. video

--- a/media_kit_video/linux/include/media_kit_video/video_output_manager.h
+++ b/media_kit_video/linux/include/media_kit_video/video_output_manager.h
@@ -25,7 +25,8 @@ G_DECLARE_FINAL_TYPE(VideoOutputManager,
                               VideoOutputManager))
 
 VideoOutputManager* video_output_manager_new(
-    FlTextureRegistrar* texture_registrar, FlView* view);
+    FlTextureRegistrar* texture_registrar,
+    FlView* view);
 
 /**
  * @brief Creates a new |VideoOutput| instance for given |handle|.
@@ -44,9 +45,7 @@ VideoOutputManager* video_output_manager_new(
  */
 void video_output_manager_create(VideoOutputManager* self,
                                  gint64 handle,
-                                 gint64 width,
-                                 gint64 height,
-                                 gboolean enable_hardware_acceleration,
+                                 VideoOutputConfiguration configuration,
                                  TextureUpdateCallback texture_update_callback,
                                  gpointer texture_update_callback_context);
 

--- a/media_kit_video/linux/texture_gl.cc
+++ b/media_kit_video/linux/texture_gl.cc
@@ -111,11 +111,20 @@ gboolean texture_gl_populate_texture(FlTextureGL* texture,
     mpv_render_context_render(render_context, params);
   }
   *target = GL_TEXTURE_2D;
-  *name = TEXTURE_GL(texture)->name;
-  *width = TEXTURE_GL(texture)->current_width;
-  *height = TEXTURE_GL(texture)->current_height;
-  if (self->name == 0 || self->fbo == 0) {
-    g_print("media_kit: TextureGL: THIS IS NOT AN ERROR. DO NOT REPORT!\n");
+  *name = self->name;
+  *width = self->current_width;
+  *height = self->current_height;
+  if (self->name == 0 && self->fbo == 0) {
+    // This means that required_width > 0 && required_height > 0 code-path
+    // hasn't been executed yet (because first frame isn't available yet).
+    // Just creating a dummy texture & FBO; prevent Flutter from complaining.
+    glGenFramebuffers(1, &self->fbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, self->fbo);
+    glGenTextures(1, &self->name);
+    glBindTexture(GL_TEXTURE_2D, self->name);
+    *name = self->name;
+    *width = 1;
+    *height = 1;
   }
   return TRUE;
 }

--- a/media_kit_video/linux/video_output.cc
+++ b/media_kit_video/linux/video_output.cc
@@ -26,7 +26,7 @@ struct _VideoOutput {
   mpv_render_context* render_context;
   gint64 width;
   gint64 height;
-  gboolean enable_hardware_acceleration;
+  VideoOutputConfiguration configuration;
   TextureUpdateCallback texture_update_callback;
   gpointer texture_update_callback_context;
   FlTextureRegistrar* texture_registrar;
@@ -72,7 +72,7 @@ static void video_output_init(VideoOutput* self) {
   self->render_context = NULL;
   self->width = 0;
   self->height = 0;
-  self->enable_hardware_acceleration = TRUE;
+  self->configuration = VideoOutputConfiguration{};
   self->texture_update_callback = NULL;
   self->texture_update_callback_context = NULL;
   self->texture_registrar = NULL;
@@ -83,42 +83,36 @@ static void video_output_init(VideoOutput* self) {
 VideoOutput* video_output_new(FlTextureRegistrar* texture_registrar,
                               FlView* view,
                               gint64 handle,
-                              gint64 width,
-                              gint64 height,
-                              gboolean enable_hardware_acceleration) {
+                              VideoOutputConfiguration configuration) {
   g_print("media_kit: VideoOutput: video_output_new: %ld\n", handle);
   VideoOutput* self = VIDEO_OUTPUT(g_object_new(video_output_get_type(), NULL));
   self->texture_registrar = texture_registrar;
   self->handle = (mpv_handle*)handle;
-  self->width = width;
-  self->height = height;
-#ifdef MPV_RENDER_API_TYPE_SW
-  self->enable_hardware_acceleration = enable_hardware_acceleration;
-#else
-  // Can't use S/W rendering if MPV_RENDER_API_TYPE_SW is not defined.
-  self->enable_hardware_acceleration = TRUE;
-  if (!enable_hardware_acceleration) {
+  self->width = configuration.width;
+  self->height = configuration.height;
+  self->configuration = configuration;
+#ifndef MPV_RENDER_API_TYPE_SW
+  // MPV_RENDER_API_TYPE_SW must be available for S/W rendering.
+  if (!self->configuration.enable_hardware_acceleration) {
     g_printerr("media_kit: VideoOutput: S/W rendering is not supported.\n");
   }
+  self->configuration.enable_hardware_acceleration = TRUE;
 #endif
   mpv_set_option_string(self->handle, "video-sync", "audio");
   mpv_set_option_string(self->handle, "video-timing-offset", "0");
   gboolean hardware_acceleration_supported = FALSE;
-  if (self->enable_hardware_acceleration) {
+  if (self->configuration.enable_hardware_acceleration) {
     GError* error = NULL;
     GdkWindow* window = gtk_widget_get_window(GTK_WIDGET(view));
-    self->gdk_gl_context =
-        gdk_window_create_gl_context(window, &error);
+    self->gdk_gl_context = gdk_window_create_gl_context(window, &error);
     if (error == NULL) {
       // OpenGL context must be made current before creating mpv render context.
       gdk_gl_context_realize(self->gdk_gl_context, &error);
       if (error == NULL) {
         // Create |FlTextureGL| and register it.
         self->texture_gl = texture_gl_new(self);
-        gboolean result = fl_texture_registrar_register_texture(
-            texture_registrar, FL_TEXTURE(self->texture_gl));
-        g_print("fl_texture_registrar_register_texture: %d\n", result);
-        if (result) {
+        if (fl_texture_registrar_register_texture(
+                texture_registrar, FL_TEXTURE(self->texture_gl))) {
           // Request H/W decoding.
           mpv_opengl_init_params gl_init_params{
               [](auto, auto name) {
@@ -149,10 +143,8 @@ VideoOutput* video_output_new(FlTextureRegistrar* texture_registrar,
             params[2].type = MPV_RENDER_PARAM_X11_DISPLAY;
             params[2].data = gdk_x11_display_get_xdisplay(display);
           }
-          gint result = mpv_render_context_create(&self->render_context,
-                                                  self->handle, params);
-          g_print("mpv_render_context_create: %d\n", result);
-          if (result == 0) {
+          if (mpv_render_context_create(&self->render_context, self->handle,
+                                        params) == 0) {
             mpv_render_context_set_update_callback(
                 self->render_context,
                 [](void* data) {

--- a/media_kit_video/linux/video_output.cc
+++ b/media_kit_video/linux/video_output.cc
@@ -101,7 +101,6 @@ VideoOutput* video_output_new(FlTextureRegistrar* texture_registrar,
     g_printerr("media_kit: VideoOutput: S/W rendering is not supported.\n");
   }
 #endif
-  mpv_set_option_string(self->handle, "vo", "libmpv");
   mpv_set_option_string(self->handle, "video-sync", "audio");
   mpv_set_option_string(self->handle, "video-timing-offset", "0");
   gboolean hardware_acceleration_supported = FALSE;
@@ -121,7 +120,6 @@ VideoOutput* video_output_new(FlTextureRegistrar* texture_registrar,
         g_print("fl_texture_registrar_register_texture: %d\n", result);
         if (result) {
           // Request H/W decoding.
-          mpv_set_option_string(self->handle, "hwdec", "auto");
           mpv_opengl_init_params gl_init_params{
               [](auto, auto name) {
                 GdkDisplay* display = gdk_display_get_default();

--- a/media_kit_video/linux/video_output_manager.cc
+++ b/media_kit_video/linux/video_output_manager.cc
@@ -33,7 +33,8 @@ static void video_output_manager_class_init(VideoOutputManagerClass* klass) {
 }
 
 VideoOutputManager* video_output_manager_new(
-    FlTextureRegistrar* texture_registrar, FlView* view) {
+    FlTextureRegistrar* texture_registrar,
+    FlView* view) {
   VideoOutputManager* video_output_manager = VIDEO_OUTPUT_MANAGER(
       g_object_new(video_output_manager_get_type(), nullptr));
   video_output_manager->texture_registrar = texture_registrar;
@@ -43,15 +44,12 @@ VideoOutputManager* video_output_manager_new(
 
 void video_output_manager_create(VideoOutputManager* self,
                                  gint64 handle,
-                                 gint64 width,
-                                 gint64 height,
-                                 gboolean enable_hardware_acceleration,
+                                 VideoOutputConfiguration configuration,
                                  TextureUpdateCallback texture_update_callback,
                                  gpointer texture_update_callback_context) {
   if (!g_hash_table_contains(self->video_outputs, GINT_TO_POINTER(handle))) {
-    g_autoptr(VideoOutput) video_output =
-        video_output_new(self->texture_registrar, self->view, handle, width, height,
-                         enable_hardware_acceleration);
+    g_autoptr(VideoOutput) video_output = video_output_new(
+        self->texture_registrar, self->view, handle, configuration);
     video_output_set_texture_update_callback(
         video_output, texture_update_callback, texture_update_callback_context);
     g_hash_table_insert(self->video_outputs, GINT_TO_POINTER(handle),

--- a/media_kit_video/macos/Classes/plugin/TextureHW.swift
+++ b/media_kit_video/macos/Classes/plugin/TextureHW.swift
@@ -60,9 +60,6 @@ public class TextureHW: NSObject, FlutterTexture, ResizableTextureProtocol {
       CGLSetCurrentContext(nil)
     }
 
-    MPVHelpers.checkError(mpv_set_option_string(handle, "vo", "libmpv"))
-    MPVHelpers.checkError(mpv_set_option_string(handle, "hwdec", "auto"))
-
     let api = UnsafeMutableRawPointer(
       mutating: (MPV_RENDER_API_TYPE_OPENGL as NSString).utf8String
     )

--- a/media_kit_video/macos/Classes/plugin/common/VideoOutputConfiguration.swift
+++ b/media_kit_video/macos/Classes/plugin/common/VideoOutputConfiguration.swift
@@ -1,0 +1,1 @@
+../../../../common/darwin/Classes/plugin/VideoOutputConfiguration.swift

--- a/media_kit_video/windows/media_kit_video_plugin.cc
+++ b/media_kit_video/windows/media_kit_video_plugin.cc
@@ -38,22 +38,31 @@ void MediaKitVideoPlugin::HandleMethodCall(
     auto arguments = std::get<flutter::EncodableMap>(*method_call.arguments());
     auto handle =
         std::get<std::string>(arguments[flutter::EncodableValue("handle")]);
-    auto width =
-        std::get<std::string>(arguments[flutter::EncodableValue("width")]);
-    auto height =
-        std::get<std::string>(arguments[flutter::EncodableValue("height")]);
-    auto enable_hardware_acceleration = std::get<bool>(
-        arguments[flutter::EncodableValue("enableHardwareAcceleration")]);
-    auto handle_value =
-        static_cast<int64_t>(strtoll(handle.c_str(), nullptr, 10));
-    auto width_value = std::optional<int64_t>{};
-    auto height_value = std::optional<int64_t>{};
-    if (height.compare("null") != 0 && width.compare("null") != 0) {
-      width_value = static_cast<int64_t>(strtoll(width.c_str(), nullptr, 10));
-      height_value = static_cast<int64_t>(strtoll(height.c_str(), nullptr, 10));
+    auto configuration = std::get<flutter::EncodableMap>(
+        arguments[flutter::EncodableValue("configuration")]);
+
+    auto handle_value = std::stoll(handle);
+    auto configuration_value = VideoOutputConfiguration{};
+
+    auto configuration_width =
+        std::get<std::string>(configuration[flutter::EncodableValue("width")]);
+    auto configuration_height =
+        std::get<std::string>(configuration[flutter::EncodableValue("height")]);
+    auto configuration_enable_hardware_acceleration = std::get<bool>(
+        configuration[flutter::EncodableValue("enableHardwareAcceleration")]);
+    if (configuration_width.compare("null") != 0) {
+      configuration_value.width =
+          static_cast<int64_t>(std::stoll(configuration_width.c_str()));
     }
+    if (configuration_height.compare("null") != 0) {
+      configuration_value.height =
+          static_cast<int64_t>(std::stoll(configuration_height.c_str()));
+    }
+    configuration_value.enable_hardware_acceleration =
+        configuration_enable_hardware_acceleration;
+
     video_output_manager_->Create(
-        handle_value, width_value, height_value, enable_hardware_acceleration,
+        handle_value, configuration_value,
         [channel_ptr = channel_.get(), handle = handle_value](
             auto id, auto width, auto height) {
           channel_ptr->InvokeMethod(
@@ -97,8 +106,7 @@ void MediaKitVideoPlugin::HandleMethodCall(
     auto arguments = std::get<flutter::EncodableMap>(*method_call.arguments());
     auto handle =
         std::get<std::string>(arguments[flutter::EncodableValue("handle")]);
-    auto handle_value =
-        static_cast<int64_t>(strtoll(handle.c_str(), nullptr, 10));
+    auto handle_value = static_cast<int64_t>(std::stoll(handle.c_str()));
     video_output_manager_->Dispose(handle_value);
     result->Success(flutter::EncodableValue(std::monostate{}));
   } else if (method_call.method_name().compare("VideoOutputManager.SetSize") ==
@@ -110,13 +118,14 @@ void MediaKitVideoPlugin::HandleMethodCall(
         std::get<std::string>(arguments[flutter::EncodableValue("width")]);
     auto height =
         std::get<std::string>(arguments[flutter::EncodableValue("height")]);
-    auto handle_value =
-        static_cast<int64_t>(strtoll(handle.c_str(), nullptr, 10));
+    auto handle_value = static_cast<int64_t>(std::stoll(handle.c_str()));
     auto width_value = std::optional<int64_t>{};
     auto height_value = std::optional<int64_t>{};
-    if (height.compare("null") != 0 && width.compare("null") != 0) {
-      width_value = static_cast<int64_t>(strtoll(width.c_str(), nullptr, 10));
-      height_value = static_cast<int64_t>(strtoll(height.c_str(), nullptr, 10));
+    if (width.compare("null") != 0) {
+      width_value = static_cast<int64_t>(std::stoll(width.c_str()));
+    }
+    if (height.compare("null") != 0) {
+      height_value = static_cast<int64_t>(std::stoll(height.c_str()));
     }
     video_output_manager_->SetSize(handle_value, width_value, height_value);
     result->Success(flutter::EncodableValue(std::monostate{}));

--- a/media_kit_video/windows/video_output.cc
+++ b/media_kit_video/windows/video_output.cc
@@ -42,7 +42,6 @@ VideoOutput::VideoOutput(int64_t handle,
   // the existing |Render| or |Resize| calls from another |VideoOutput|
   // instances (which will result in access violation).
   auto future = thread_pool_ref_->Post([&]() {
-    mpv_set_option_string(handle_, "vo", "libmpv");
     mpv_set_option_string(handle_, "video-sync", "audio");
     mpv_set_option_string(handle_, "video-timing-offset", "0");
     // First try to initialize video playback with hardware acceleration &
@@ -67,8 +66,6 @@ VideoOutput::VideoOutput(int64_t handle,
             {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &gl_init_params},
             {MPV_RENDER_PARAM_INVALID, nullptr},
         };
-        // Request H/W decoding.
-        mpv_set_option_string(handle_, "hwdec", "auto");
         // Create render context.
         if (mpv_render_context_create(&render_context_, handle_, params) == 0) {
           mpv_render_context_set_update_callback(

--- a/media_kit_video/windows/video_output.cc
+++ b/media_kit_video/windows/video_output.cc
@@ -26,15 +26,13 @@
   (SW_RENDERING_MAX_WIDTH) * (SW_RENDERING_MAX_HEIGHT) * (4)
 
 VideoOutput::VideoOutput(int64_t handle,
-                         std::optional<int64_t> width,
-                         std::optional<int64_t> height,
-                         bool enable_hardware_acceleration,
+                         VideoOutputConfiguration configuration,
                          flutter::PluginRegistrarWindows* registrar,
                          ThreadPool* thread_pool_ref)
     : handle_(reinterpret_cast<mpv_handle*>(handle)),
-      width_(width),
-      height_(height),
-      enable_hardware_acceleration_(enable_hardware_acceleration),
+      width_(configuration.width),
+      height_(configuration.height),
+      configuration_(configuration),
       registrar_(registrar),
       thread_pool_ref_(thread_pool_ref) {
   // The constructor must be invoked through the thread pool, because
@@ -48,7 +46,7 @@ VideoOutput::VideoOutput(int64_t handle,
     // |ANGLESurfaceManager|, use S/W API as fallback.
     auto is_hardware_acceleration_enabled = false;
     // Attempt to use H/W rendering.
-    if (enable_hardware_acceleration_) {
+    if (configuration.enable_hardware_acceleration) {
       try {
         // OpenGL context needs to be set before |mpv_render_context_create|.
         surface_manager_ = std::make_unique<ANGLESurfaceManager>(

--- a/media_kit_video/windows/video_output.h
+++ b/media_kit_video/windows/video_output.h
@@ -25,6 +25,19 @@
 #include "angle_surface_manager.h"
 #include "thread_pool.h"
 
+typedef struct _VideoOutputConfiguration {
+  std::optional<int64_t> width;
+  std::optional<int64_t> height;
+  bool enable_hardware_acceleration;
+
+  _VideoOutputConfiguration(std::optional<int64_t> width = std::nullopt,
+                            std::optional<int64_t> height = std::nullopt,
+                            bool enable_hardware_acceleration = true)
+      : width(width),
+        height(height),
+        enable_hardware_acceleration(enable_hardware_acceleration) {}
+} VideoOutputConfiguration;
+
 class VideoOutput {
  public:
   int64_t texture_id() const { return texture_id_; }
@@ -52,9 +65,7 @@ class VideoOutput {
   }
 
   VideoOutput(int64_t handle,
-              std::optional<int64_t> width,
-              std::optional<int64_t> height,
-              bool enable_hardware_acceleration,
+              VideoOutputConfiguration configuration,
               flutter::PluginRegistrarWindows* registrar,
               ThreadPool* thread_pool_ref);
 
@@ -78,11 +89,12 @@ class VideoOutput {
 
   int64_t GetVideoHeight();
 
-  mpv_handle* handle_ = nullptr;
-  mpv_render_context* render_context_ = nullptr;
   std::optional<int64_t> height_ = std::nullopt;
   std::optional<int64_t> width_ = std::nullopt;
-  bool enable_hardware_acceleration_ = true;
+  VideoOutputConfiguration configuration_ = VideoOutputConfiguration{};
+
+  mpv_handle* handle_ = nullptr;
+  mpv_render_context* render_context_ = nullptr;
   int64_t texture_id_ = 0;
   flutter::PluginRegistrarWindows* registrar_ = nullptr;
   ThreadPool* thread_pool_ref_ = nullptr;

--- a/media_kit_video/windows/video_output_manager.cc
+++ b/media_kit_video/windows/video_output_manager.cc
@@ -14,16 +14,13 @@ VideoOutputManager::VideoOutputManager(
 
 void VideoOutputManager::Create(
     int64_t handle,
-    std::optional<int64_t> width,
-    std::optional<int64_t> height,
-    bool enable_hardware_acceleration,
+    VideoOutputConfiguration configuration,
     std::function<void(int64_t, int64_t, int64_t)> texture_update_callback) {
   std::thread([=]() {
     std::lock_guard<std::mutex> lock(mutex_);
     if (video_outputs_.find(handle) == video_outputs_.end()) {
       auto instance = std::make_unique<VideoOutput>(
-          handle, width, height, enable_hardware_acceleration, registrar_,
-          thread_pool_.get());
+          handle, configuration, registrar_, thread_pool_.get());
       instance->SetTextureUpdateCallback(texture_update_callback);
       video_outputs_.insert(std::make_pair(handle, std::move(instance)));
     }

--- a/media_kit_video/windows/video_output_manager.h
+++ b/media_kit_video/windows/video_output_manager.h
@@ -30,9 +30,7 @@ class VideoOutputManager {
   // notified via the |texture_update_callback|.
   void Create(
       int64_t handle,
-      std::optional<int64_t> width,
-      std::optional<int64_t> height,
-      bool enable_hardware_acceleration,
+      VideoOutputConfiguration configuration,
       std::function<void(int64_t, int64_t, int64_t)> texture_update_callback);
 
   // Sets the required video output size.


### PR DESCRIPTION
Added a new `VideoControllerConfiguration` class to use in composition with `VideoController`.

Similar to `PlayerConfiguration` in `Player`; like we have it already. As we are moving ahead, people seem to require more specific things & this makes things bit more opinionated IMO.



~~Also:~~

~~Should `enableHardwareAcceleration` be moved to `VideoControllerConfiguration` as-well?~~
~~We should also give a thought to `width` & `height` then; because they are mutable (thanks to `setSize` API).~~