### PR TITLE
feat: iOS Picture in Picture support

### DIFF
--- a/media_kit/lib/src/models/player_streams.dart
+++ b/media_kit/lib/src/models/player_streams.dart
@@ -83,6 +83,9 @@ class PlayerStreams {
   /// Currently playing video's height.
   final Stream<int> height;
 
+  /// Fired on video position seek.
+  final Stream<Duration> seek;
+
   /// {@macro player_streams}
   const PlayerStreams(
     this.playlist,
@@ -105,5 +108,6 @@ class PlayerStreams {
     this.tracks,
     this.width,
     this.height,
+    this.seek,
   );
 }

--- a/media_kit/lib/src/player/libmpv/player/real.dart
+++ b/media_kit/lib/src/player/libmpv/player/real.dart
@@ -523,6 +523,8 @@ class libmpvPlayer extends PlatformPlayer {
         args.cast(),
       );
       calloc.free(args);
+
+      seekController.add(duration);
     }
 
     if (synchronized) {

--- a/media_kit/lib/src/player/platform_player.dart
+++ b/media_kit/lib/src/player/platform_player.dart
@@ -61,6 +61,7 @@ abstract class PlatformPlayer {
     tracksController.stream,
     widthController.stream,
     heightController.stream,
+    seekController.stream,
   );
 
   @mustCallSuper
@@ -87,6 +88,7 @@ abstract class PlatformPlayer {
         tracksController.close(),
         widthController.close(),
         heightController.close(),
+        seekController.close(),
       ],
     );
     for (final callback in release) {
@@ -307,6 +309,10 @@ abstract class PlatformPlayer {
   @protected
   final StreamController<int> heightController =
       StreamController<int>.broadcast();
+
+  @protected
+  final StreamController<Duration> seekController =
+      StreamController<Duration>.broadcast();
 
   /// Publicly defined clean-up [Function]s which must be called before [dispose].
   final List<Future<void> Function()> release = [];

--- a/media_kit_test/ios/Runner/Info-Debug.plist
+++ b/media_kit_test/ios/Runner/Info-Debug.plist
@@ -26,8 +26,16 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_dartobservatory._tcp</string>
+	</array>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -47,9 +55,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>NSBonjourServices</key>
-	<array>
-	    <string>_dartobservatory._tcp</string>
-	</array>
 </dict>
 </plist>

--- a/media_kit_test/ios/Runner/Info-Profile.plist
+++ b/media_kit_test/ios/Runner/Info-Profile.plist
@@ -28,6 +28,10 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/media_kit_test/ios/Runner/Info-Release.plist
+++ b/media_kit_test/ios/Runner/Info-Release.plist
@@ -28,6 +28,10 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/media_kit_test/lib/common/widgets.dart
+++ b/media_kit_test/lib/common/widgets.dart
@@ -168,13 +168,15 @@ class _SeekBarState extends State<SeekBar> {
 
   @override
   Widget build(BuildContext context) {
-    final horizontal = MediaQuery.of(context).size.width > MediaQuery.of(context).size.height;
+    final horizontal =
+        MediaQuery.of(context).size.width > MediaQuery.of(context).size.height;
     return Column(
       children: [
         const SizedBox(height: 16.0),
         if (!horizontal)
           Row(
             children: [
+              const SizedBox(width: 36),
               const Spacer(),
               IconButton(
                 onPressed: widget.player.playOrPause,
@@ -186,8 +188,9 @@ class _SeekBarState extends State<SeekBar> {
               ),
               const Spacer(),
               IconButton(
-                onPressed:
-                    widget.controller.isPictureInPictureAvailable() ? widget.controller.enterPictureInPicture : null,
+                onPressed: widget.controller.isPictureInPictureAvailable()
+                    ? widget.controller.enterPictureInPicture
+                    : null,
                 icon: const Icon(
                   Icons.picture_in_picture,
                 ),

--- a/media_kit_test/lib/common/widgets.dart
+++ b/media_kit_test/lib/common/widgets.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import 'package:media_kit/media_kit.dart';
+import 'package:media_kit_video/media_kit_video.dart';
 
 class TracksSelector extends StatefulWidget {
   final Player player;
@@ -97,9 +98,12 @@ class _TracksSelectorState extends State<TracksSelector> {
 
 class SeekBar extends StatefulWidget {
   final Player player;
+  final VideoController controller;
+
   const SeekBar({
     Key? key,
     required this.player,
+    required this.controller,
   }) : super(key: key);
 
   @override
@@ -164,8 +168,7 @@ class _SeekBarState extends State<SeekBar> {
 
   @override
   Widget build(BuildContext context) {
-    final horizontal =
-        MediaQuery.of(context).size.width > MediaQuery.of(context).size.height;
+    final horizontal = MediaQuery.of(context).size.width > MediaQuery.of(context).size.height;
     return Column(
       children: [
         const SizedBox(height: 16.0),
@@ -182,6 +185,15 @@ class _SeekBarState extends State<SeekBar> {
                 iconSize: 36.0,
               ),
               const Spacer(),
+              IconButton(
+                onPressed:
+                    widget.controller.isPictureInPictureAvailable() ? widget.controller.enterPictureInPicture : null,
+                icon: const Icon(
+                  Icons.picture_in_picture,
+                ),
+                color: Theme.of(context).primaryColor,
+                iconSize: 36.0,
+              ),
             ],
           ),
         Row(

--- a/media_kit_test/lib/tests/01.single_player_single_video.dart
+++ b/media_kit_test/lib/tests/01.single_player_single_video.dart
@@ -43,6 +43,7 @@ class _SinglePlayerSingleVideoScreenState
             ),
             onTap: () {
               player.open(Media(sources[i]));
+              controller.enableAutoPictureInPicture();
             },
           ),
       ];
@@ -104,7 +105,7 @@ class _SinglePlayerSingleVideoScreenState
                               ),
                             ),
                           ),
-                          SeekBar(player: player),
+                          SeekBar(player: player, controller: controller),
                           const SizedBox(height: 32.0),
                         ],
                       ),
@@ -127,7 +128,7 @@ class _SinglePlayerSingleVideoScreenState
                     height: MediaQuery.of(context).size.width * 9.0 / 16.0,
                   ),
                   const SizedBox(height: 16.0),
-                  SeekBar(player: player),
+                  SeekBar(player: player, controller: controller),
                   const SizedBox(height: 32.0),
                   const Divider(height: 1.0, thickness: 1.0),
                   ...items,

--- a/media_kit_test/lib/tests/02.single_player_multiple_video.dart
+++ b/media_kit_test/lib/tests/02.single_player_multiple_video.dart
@@ -12,12 +12,10 @@ class SinglePlayerMultipleVideoScreen extends StatefulWidget {
   const SinglePlayerMultipleVideoScreen({Key? key}) : super(key: key);
 
   @override
-  State<SinglePlayerMultipleVideoScreen> createState() =>
-      _SinglePlayerMultipleVideoScreenState();
+  State<SinglePlayerMultipleVideoScreen> createState() => _SinglePlayerMultipleVideoScreenState();
 }
 
-class _SinglePlayerMultipleVideoScreenState
-    extends State<SinglePlayerMultipleVideoScreen> {
+class _SinglePlayerMultipleVideoScreenState extends State<SinglePlayerMultipleVideoScreen> {
   late final Player player = Player();
   // NOTE: A single [VideoController] is enough for multiple [Video] widgets (& more efficient).
   //       Here, two [VideoController]s are created for testing.
@@ -55,8 +53,7 @@ class _SinglePlayerMultipleVideoScreenState
 
   @override
   Widget build(BuildContext context) {
-    final horizontal =
-        MediaQuery.of(context).size.width > MediaQuery.of(context).size.height;
+    final horizontal = MediaQuery.of(context).size.width > MediaQuery.of(context).size.height;
     return Scaffold(
       appBar: AppBar(
         title: const Text('package:media_kit'),
@@ -110,24 +107,16 @@ class _SinglePlayerMultipleVideoScreenState
                                 Expanded(
                                   child: Row(
                                     children: [
-                                      Expanded(
-                                          child:
-                                              Video(controller: controller0)),
-                                      Expanded(
-                                          child:
-                                              Video(controller: controller0)),
+                                      Expanded(child: Video(controller: controller0)),
+                                      Expanded(child: Video(controller: controller0)),
                                     ],
                                   ),
                                 ),
                                 Expanded(
                                   child: Row(
                                     children: [
-                                      Expanded(
-                                          child:
-                                              Video(controller: controller1)),
-                                      Expanded(
-                                          child:
-                                              Video(controller: controller1)),
+                                      Expanded(child: Video(controller: controller1)),
+                                      Expanded(child: Video(controller: controller1)),
                                     ],
                                   ),
                                 ),
@@ -135,7 +124,7 @@ class _SinglePlayerMultipleVideoScreenState
                             ),
                           ),
                         ),
-                        SeekBar(player: player),
+                        SeekBar(player: player, controller: controller0),
                         const SizedBox(height: 32.0),
                       ],
                     ),
@@ -177,7 +166,7 @@ class _SinglePlayerMultipleVideoScreenState
                       ],
                     ),
                   ),
-                  SeekBar(player: player),
+                  SeekBar(player: player, controller: controller0),
                   const SizedBox(height: 32.0),
                   const Divider(height: 1.0, thickness: 1.0),
                   ...items,

--- a/media_kit_test/lib/tests/03.multiple_player_multiple_video.dart
+++ b/media_kit_test/lib/tests/03.multiple_player_multiple_video.dart
@@ -11,12 +11,10 @@ class MultiplePlayerMultipleVideoScreen extends StatefulWidget {
   const MultiplePlayerMultipleVideoScreen({Key? key}) : super(key: key);
 
   @override
-  State<MultiplePlayerMultipleVideoScreen> createState() =>
-      _MultiplePlayerMultipleVideoScreenState();
+  State<MultiplePlayerMultipleVideoScreen> createState() => _MultiplePlayerMultipleVideoScreenState();
 }
 
-class _MultiplePlayerMultipleVideoScreenState
-    extends State<MultiplePlayerMultipleVideoScreen> {
+class _MultiplePlayerMultipleVideoScreenState extends State<MultiplePlayerMultipleVideoScreen> {
   late final List<Player> players = [
     Player(),
     Player(),
@@ -72,7 +70,7 @@ class _MultiplePlayerMultipleVideoScreenState
                     ),
                   ),
                 ),
-                SeekBar(player: players[i]),
+                SeekBar(player: players[i], controller: controllers[i]),
                 const SizedBox(height: 32.0),
               ],
             )
@@ -84,8 +82,7 @@ class _MultiplePlayerMultipleVideoScreenState
 
   @override
   Widget build(BuildContext context) {
-    final horizontal =
-        MediaQuery.of(context).size.width > MediaQuery.of(context).size.height;
+    final horizontal = MediaQuery.of(context).size.width > MediaQuery.of(context).size.height;
     return Scaffold(
       appBar: AppBar(
         title: const Text('package:media_kit'),
@@ -100,10 +97,7 @@ class _MultiplePlayerMultipleVideoScreenState
                         Container(
                           alignment: Alignment.center,
                           width: MediaQuery.of(context).size.width / 2,
-                          height: MediaQuery.of(context).size.width /
-                              2 *
-                              12.0 /
-                              16.0,
+                          height: MediaQuery.of(context).size.width / 2 * 12.0 / 16.0,
                           child: getVideoForIndex(context, i),
                         ),
                         const Divider(height: 1.0, thickness: 1.0),

--- a/media_kit_video/common/darwin/Classes/plugin/MediaKitVideoPlugin.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/MediaKitVideoPlugin.swift
@@ -8,13 +8,13 @@ public class MediaKitVideoPlugin: NSObject, FlutterPlugin {
   private static let CHANNEL_NAME = "com.alexmercerind/media_kit_video"
 
   public static func register(with registrar: FlutterPluginRegistrar) {
-    #if canImport(Flutter)
-      let binaryMessenger = registrar.messenger()
-      let registry = registrar.textures()
-    #elseif canImport(FlutterMacOS)
-      let binaryMessenger = registrar.messenger
-      let registry = registrar.textures
-    #endif
+#if canImport(Flutter)
+    let binaryMessenger = registrar.messenger()
+    let registry = registrar.textures()
+#elseif canImport(FlutterMacOS)
+    let binaryMessenger = registrar.messenger
+    let registry = registrar.textures
+#endif
 
     let channel = FlutterMethodChannel(
       name: CHANNEL_NAME,
@@ -46,6 +46,20 @@ public class MediaKitVideoPlugin: NSObject, FlutterPlugin {
       handleCreateMethodCall(call.arguments, result)
     case "VideoOutputManager.SetSize":
       handleSetSizeMethodCall(call.arguments, result)
+    case "VideoOutputManager.IsPictureInPictureAvailable":
+      handleIsPictureInPictureAvailableMethodCall(call.arguments, result)
+    case "VideoOutputManager.EnablePictureInPicture":
+      handleEnablePictureInPictureMethodCall(call.arguments, result)
+    case "VideoOutputManager.DisablePictureInPicture":
+      handleDisablePictureInPictureMethodCall(call.arguments, result)
+    case "VideoOutputManager.EnableAutoPictureInPicture":
+      handleEnableAutoPictureInPictureMethodCall(call.arguments, result)
+    case "VideoOutputManager.DisableAutoPictureInPicture":
+      handleDisableAutoPictureInPictureMethodCall(call.arguments, result)
+    case "VideoOutputManager.EnterPictureInPicture":
+      handleEnterPictureInPictureMethodCall(call.arguments, result)
+    case "VideoOutputManager.RefreshPlaybackState":
+      handleRefreshPlaybackStateMethodCall(call.arguments, result)
     case "VideoOutputManager.Dispose":
       handleDisposeMethodCall(call.arguments, result)
     default:
@@ -62,7 +76,7 @@ public class MediaKitVideoPlugin: NSObject, FlutterPlugin {
     let widthStr = args?["width"] as! String
     let heightStr = args?["height"] as! String
     let enableHardwareAcceleration =
-      args?["enableHardwareAcceleration"] as! Bool
+    args?["enableHardwareAcceleration"] as! Bool
 
     let handle: Int64? = Int64(handleStr)
     let width: Int64? = Int64(widthStr)
@@ -114,6 +128,116 @@ public class MediaKitVideoPlugin: NSObject, FlutterPlugin {
       handle: handle!,
       width: width,
       height: height
+    )
+
+    result(nil)
+  }
+
+  private func handleIsPictureInPictureAvailableMethodCall(
+    _ arguments: Any?,
+    _ result: FlutterResult
+  ) {
+    let ret = videoOutputManager.isPictureInPictureAvailable()
+
+    result(ret)
+  }
+  private func handleEnableAutoPictureInPictureMethodCall(
+    _ arguments: Any?,
+    _ result: FlutterResult
+  ) {
+    let args = arguments as? [String: Any]
+    let handleStr = args?["handle"] as! String
+    let handle: Int64? = Int64(handleStr)
+
+    assert(handle != nil, "handle must be an Int64")
+
+    let ret = videoOutputManager.enableAutoPictureInPicture(
+      handle: handle!
+    )
+
+    result(ret)
+  }
+
+  private func handleEnablePictureInPictureMethodCall(
+    _ arguments: Any?,
+    _ result: FlutterResult
+  ) {
+    let args = arguments as? [String: Any]
+    let handleStr = args?["handle"] as! String
+    let handle: Int64? = Int64(handleStr)
+
+    assert(handle != nil, "handle must be an Int64")
+
+    let ret = videoOutputManager.enablePictureInPicture(
+      handle: handle!
+    )
+
+    result(ret)
+  }
+
+  private func handleDisablePictureInPictureMethodCall(
+    _ arguments: Any?,
+    _ result: FlutterResult
+  ) {
+    let args = arguments as? [String: Any]
+    let handleStr = args?["handle"] as! String
+    let handle: Int64? = Int64(handleStr)
+
+    assert(handle != nil, "handle must be an Int64")
+
+    videoOutputManager.disablePictureInPicture(
+      handle: handle!
+    )
+
+    result(nil)
+  }
+
+  private func handleDisableAutoPictureInPictureMethodCall(
+    _ arguments: Any?,
+    _ result: FlutterResult
+  ) {
+    let args = arguments as? [String: Any]
+    let handleStr = args?["handle"] as! String
+    let handle: Int64? = Int64(handleStr)
+
+    assert(handle != nil, "handle must be an Int64")
+
+    videoOutputManager.disableAutoPictureInPicture(
+      handle: handle!
+    )
+
+    result(nil)
+  }
+
+  private func handleEnterPictureInPictureMethodCall(
+    _ arguments: Any?,
+    _ result: FlutterResult
+  ) {
+    let args = arguments as? [String: Any]
+    let handleStr = args?["handle"] as! String
+    let handle: Int64? = Int64(handleStr)
+
+    assert(handle != nil, "handle must be an Int64")
+
+    let ret = videoOutputManager.enterPictureInPicture(
+      handle: handle!
+    )
+
+    result(ret)
+  }
+
+  private func handleRefreshPlaybackStateMethodCall(
+    _ arguments: Any?,
+    _ result: FlutterResult
+  ) {
+    let args = arguments as? [String: Any]
+    let handleStr = args?["handle"] as! String
+    let handle: Int64? = Int64(handleStr)
+
+    assert(handle != nil, "handle must be an Int64")
+
+    videoOutputManager.refreshPlaybackState(
+      handle: handle!
     )
 
     result(nil)

--- a/media_kit_video/common/darwin/Classes/plugin/TextureSW.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/TextureSW.swift
@@ -67,6 +67,7 @@ public class TextureSW: NSObject, FlutterTexture, ResizableTextureProtocol {
   }
 
   private func disposeMPV() {
+    mpv_render_context_set_update_callback(handle, nil, nil)
     mpv_render_context_free(renderContext)
   }
 

--- a/media_kit_video/common/darwin/Classes/plugin/TextureSW.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/TextureSW.swift
@@ -24,9 +24,7 @@ public class TextureSW: NSObject, FlutterTexture, ResizableTextureProtocol {
 
     super.init()
 
-    DispatchQueue.main.async {
-      self.initMPV()
-    }
+    self.initMPV()
   }
 
   public func copyPixelBuffer() -> Unmanaged<CVPixelBuffer>? {

--- a/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
@@ -31,8 +31,6 @@ public class VideoOutput: NSObject {
   internal let worker: Worker = .init()
   private var width: Int64?
   private var height: Int64?
-  internal var userSetWidth: Int64?
-  internal var userSetHeight: Int64?
   internal var texture: ResizableTextureProtocol!
   private var textureId: Int64 = -1
   private var currentWidth: Int64 = 0
@@ -93,15 +91,9 @@ public class VideoOutput: NSObject {
   
   public func setSize(width: Int64?, height: Int64?) {
     worker.enqueue {
-      self.userSetWidth = width
-      self.userSetHeight = height
-      self._setTextureSize(width: width, height: height)
+      self.width = width
+      self.height = height
     }
-  }
-  
-  public func _setTextureSize(width: Int64?, height: Int64?) {
-    self.width = width
-    self.height = height
   }
   
   public func refreshPlaybackState() {}

--- a/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
@@ -4,12 +4,6 @@ import Flutter
 import FlutterMacOS
 #endif
 
-import AVKit
-
-#if os(iOS)
-import UIKit
-#endif
-
 // This class creates and manipulates the different types of FlutterTexture,
 // handles resizing, rendering calls, and notify Flutter when a new frame is
 // available to render.
@@ -29,17 +23,17 @@ public class VideoOutput: NSObject {
     return isSim
   }()
   
-  fileprivate let handle: OpaquePointer
+  internal let handle: OpaquePointer
   private let enableHardwareAcceleration: Bool
   private var usingHardwareAcceleration: Bool
   private let registry: FlutterTextureRegistry
   private let textureUpdateCallback: TextureUpdateCallback
-  fileprivate let worker: Worker = .init()
+  internal let worker: Worker = .init()
   private var width: Int64?
   private var height: Int64?
-  fileprivate var userSetWidth: Int64?
-  fileprivate var userSetHeight: Int64?
-  fileprivate var texture: ResizableTextureProtocol!
+  internal var userSetWidth: Int64?
+  internal var userSetHeight: Int64?
+  internal var texture: ResizableTextureProtocol!
   private var textureId: Int64 = -1
   private var currentWidth: Int64 = 0
   private var currentHeight: Int64 = 0
@@ -184,7 +178,7 @@ public class VideoOutput: NSObject {
     }
   }
   
-  fileprivate func _updateCallback() {
+  internal func _updateCallback() {
     let width = videoWidth
     let height = videoHeight
     
@@ -238,211 +232,3 @@ public class VideoOutput: NSObject {
     return height
   }
 }
-
-#if os(iOS)
-@available(iOS 15.0, *)
-public class VideoOutputWithPIP: VideoOutput, AVPictureInPictureSampleBufferPlaybackDelegate, AVPictureInPictureControllerDelegate {
-  private var bufferDisplayLayer: AVSampleBufferDisplayLayer = AVSampleBufferDisplayLayer()
-  private var pipController: AVPictureInPictureController? = nil
-  private var videoFormat: CMVideoFormatDescription? = nil
-  private var notificationCenter: NotificationCenter {
-    return .default
-  }
-  
-  override init(handle: Int64, configuration: VideoOutputConfiguration, registry: FlutterTextureRegistry, textureUpdateCallback: @escaping VideoOutput.TextureUpdateCallback) {
-    super.init(handle: handle, configuration: configuration, registry: registry, textureUpdateCallback: textureUpdateCallback)
-    
-    notificationCenter.addObserver(self, selector: #selector(appWillResignActive(_:)), name: UIApplication.willResignActiveNotification, object: nil)
-    notificationCenter.addObserver(self, selector: #selector(appWillEnterForeground(_:)), name: UIApplication.willEnterForegroundNotification, object: nil)
-  }
-  
-  deinit {
-    notificationCenter.removeObserver(self)
-  }
-  
-  @objc private func appWillEnterForeground(_ notification: NSNotification) {
-    worker.enqueue {
-      self.switchToHardwareRendering()
-    }
-  }
-  
-  @objc private func appWillResignActive(_ notification: NSNotification) {
-    if pipController == nil {
-      return
-    }
-    
-    if pipController!.canStartPictureInPictureAutomaticallyFromInline || pipController!.isPictureInPictureActive {
-      switchToSoftwareRendering()
-      return
-    }
-    
-    var isPaused: Int8 = 0
-    mpv_get_property(handle, "pause", MPV_FORMAT_FLAG, &isPaused)
-    
-    if isPaused == 1 {
-      return
-    }
-    
-    // Pause if apps goes into background and PiP is not enabled.
-    // Otherwise audio and video will continue playing.
-    mpv_command_string(handle, "cycle pause")
-  }
-  
-  override public func refreshPlaybackState() {
-    pipController?.invalidatePlaybackState()
-  }
-  
-  override public func enablePictureInPicture() -> Bool {
-    if pipController != nil {
-      return true
-    }
-    
-    bufferDisplayLayer.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
-    bufferDisplayLayer.opacity = 0
-    bufferDisplayLayer.videoGravity = .resizeAspect
-    
-    let contentSource = AVPictureInPictureController.ContentSource(sampleBufferDisplayLayer: bufferDisplayLayer, playbackDelegate: self)
-    pipController = AVPictureInPictureController(contentSource: contentSource)
-    pipController!.delegate = self
-    
-    // keyWindow is deprecated but currently flutter uses it internally just as well.
-    // See Flutter issue: https://github.com/flutter/flutter/issues/104117
-    let controller = UIApplication.shared.keyWindow?.rootViewController
-    // Add bufferDisplayLayer as an invisible layer to view to make PIP work.
-    controller?.view.layer.addSublayer(bufferDisplayLayer)
-    
-    return true
-  }
-  
-  override public func disablePictureInPicture() {
-    if bufferDisplayLayer.superlayer != nil {
-      bufferDisplayLayer.removeFromSuperlayer()
-    }
-    
-    pipController = nil
-  }
-  
-  override public func enableAutoPictureInPicture() -> Bool {
-    if enablePictureInPicture() {
-      pipController?.canStartPictureInPictureAutomaticallyFromInline = true
-      return true
-    }
-    
-    return false
-  }
-  
-  override public func disableAutoPictureInPicture() {
-    if pipController != nil {
-      pipController?.canStartPictureInPictureAutomaticallyFromInline = false
-    }
-  }
-  
-  override public func enterPictureInPicture() -> Bool {
-    if enablePictureInPicture() {
-      pipController?.startPictureInPicture()
-      return true
-    }
-    
-    return false
-  }
-  
-  override func _updateCallback() {
-    super._updateCallback()
-    
-    if pipController != nil {
-      let pixelBuffer = texture.copyPixelBuffer()?.takeUnretainedValue()
-      if pixelBuffer == nil {
-        return
-      }
-      
-      var sampleBuffer: CMSampleBuffer?
-      
-      if videoFormat == nil || !CMVideoFormatDescriptionMatchesImageBuffer(videoFormat!, imageBuffer: pixelBuffer!)  {
-        videoFormat = nil
-        
-        let err = CMVideoFormatDescriptionCreateForImageBuffer(allocator: kCFAllocatorDefault, imageBuffer: pixelBuffer!, formatDescriptionOut: &videoFormat)
-        if (err != noErr) {
-          NSLog("Error at CMVideoFormatDescriptionCreateForImageBuffer \(err)")
-        }
-      }
-      
-      var sampleTimingInfo = CMSampleTimingInfo(duration: .invalid, presentationTimeStamp: CMTime(seconds: CACurrentMediaTime(), preferredTimescale: 100), decodeTimeStamp: .invalid)
-      
-      let err = CMSampleBufferCreateForImageBuffer(allocator: nil, imageBuffer: pixelBuffer!, dataReady: true, makeDataReadyCallback: nil, refcon: nil, formatDescription: videoFormat!, sampleTiming: &sampleTimingInfo, sampleBufferOut: &sampleBuffer)
-      if err == noErr {
-        bufferDisplayLayer.enqueue(sampleBuffer!)
-      } else {
-        NSLog("Error at CMSampleBufferCreateForImageBuffer \(err)")
-      }
-    }
-  }
-  
-  public override func dispose() {
-    super.dispose()
-    disablePictureInPicture()
-  }
-  
-  public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, setPlaying playing: Bool) {
-    var isPaused: Int8 = 0
-    mpv_get_property(handle, "pause", MPV_FORMAT_FLAG, &isPaused)
-    
-    if playing == (isPaused == 0) {
-      return
-    }
-    
-    mpv_command_string(handle, "cycle pause")
-  }
-  
-  public func pictureInPictureControllerTimeRangeForPlayback(_ pictureInPictureController: AVPictureInPictureController) -> CMTimeRange {
-    var position: Double = 0
-    mpv_get_property(handle, "time-pos", MPV_FORMAT_DOUBLE, &position)
-    
-    var duration: Double = 0
-    mpv_get_property(handle, "duration", MPV_FORMAT_DOUBLE, &duration)
-    
-    return CMTimeRange(
-      start:  CMTime(
-        seconds: CACurrentMediaTime() - position,
-        preferredTimescale: 100
-      ),
-      duration: CMTime(
-        seconds: duration,
-        preferredTimescale: 100
-      )
-    )
-  }
-  
-  public func pictureInPictureControllerIsPlaybackPaused(_ pictureInPictureController: AVPictureInPictureController) -> Bool {
-    var isPaused: Int8 = 0
-    mpv_get_property(handle, "pause", MPV_FORMAT_FLAG, &isPaused)
-    
-    return isPaused == 1
-  }
-  
-  public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, didTransitionToRenderSize newRenderSize: CMVideoDimensions) {
-    NSLog("Resize texture due to PIP new size: \(newRenderSize)")
-    
-    worker.enqueue {
-      if newRenderSize.width == 0 || newRenderSize.height == 0 {
-        self._setTextureSize(width: nil, height: nil)
-      } else {
-        self._setTextureSize(width: Int64(CGFloat(newRenderSize.width) * UIScreen.main.scale),
-                             height: Int64(CGFloat(newRenderSize.height) * UIScreen.main.scale))
-      }
-    }
-  }
-  
-  public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, skipByInterval skipInterval: CMTime, completion completionHandler: @escaping () -> Void) {
-    mpv_command_string(handle, "seek \(skipInterval.seconds)")
-    completionHandler()
-  }
-  
-  public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, failedToStartPictureInPictureWithError error: Error) {
-    NSLog("pictureInPictureController error: \(error)")
-  }
-  
-  public func pictureInPictureControllerWillStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
-    self.setSize(width: userSetWidth, height: userSetHeight)
-  }
-}
-#endif

--- a/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
@@ -5,8 +5,10 @@
 #endif
 
 import AVKit
-import AVFoundation
+
+#if os(iOS)
 import UIKit
+#endif
 
 // This class creates and manipulates the different types of FlutterTexture,
 // handles resizing, rendering calls, and notify Flutter when a new frame is
@@ -14,7 +16,7 @@ import UIKit
 //
 // To improve the user experience, a worker is used to execute heavy tasks on a
 // dedicated thread.
-public class VideoOutput: NSObject, AVPictureInPictureSampleBufferPlaybackDelegate, AVPictureInPictureControllerDelegate {
+public class VideoOutput: NSObject {
   public typealias TextureUpdateCallback = (Int64, CGSize) -> Void
 
   private static let isSimulator: Bool = {
@@ -27,29 +29,21 @@ public class VideoOutput: NSObject, AVPictureInPictureSampleBufferPlaybackDelega
     return isSim
   }()
 
-  private let handle: OpaquePointer
+  fileprivate let handle: OpaquePointer
   private let enableHardwareAcceleration: Bool
   private var usingHardwareAcceleration: Bool
   private let registry: FlutterTextureRegistry
   private let textureUpdateCallback: TextureUpdateCallback
-  private let worker: Worker = .init()
+  fileprivate let worker: Worker = .init()
   private var width: Int64?
   private var height: Int64?
-  private var userSetWidth: Int64?
-  private var userSetHeight: Int64?
-  private var texture: ResizableTextureProtocol!
+  fileprivate var userSetWidth: Int64?
+  fileprivate var userSetHeight: Int64?
+  fileprivate var texture: ResizableTextureProtocol!
   private var textureId: Int64 = -1
   private var currentWidth: Int64 = 0
   private var currentHeight: Int64 = 0
   private var disposed: Bool = false
-
-  private let pipAvailable: Bool
-  private var bufferDisplayLayer: AVSampleBufferDisplayLayer = AVSampleBufferDisplayLayer()
-  private var pipController: AVPictureInPictureController? = nil
-  private var videoFormat: CMVideoFormatDescription? = nil
-  private var notificationCenter: NotificationCenter {
-      return .default
-  }
 
   init(
     handle: Int64,
@@ -57,8 +51,7 @@ public class VideoOutput: NSObject, AVPictureInPictureSampleBufferPlaybackDelega
     height: Int64?,
     enableHardwareAcceleration: Bool,
     registry: FlutterTextureRegistry,
-    textureUpdateCallback: @escaping TextureUpdateCallback,
-    pipAvailable: Bool
+    textureUpdateCallback: @escaping TextureUpdateCallback
   ) {
     let handle = OpaquePointer(bitPattern: Int(handle))
     assert(handle != nil, "handle casting")
@@ -70,55 +63,14 @@ public class VideoOutput: NSObject, AVPictureInPictureSampleBufferPlaybackDelega
     self.usingHardwareAcceleration = self.enableHardwareAcceleration
     self.registry = registry
     self.textureUpdateCallback = textureUpdateCallback
-    self.pipAvailable = pipAvailable
 
     super.init()
-    
-    notificationCenter.addObserver(self, selector: #selector(appWillResignActive(_:)), name: UIApplication.willResignActiveNotification, object: nil)
-    notificationCenter.addObserver(self, selector: #selector(appWillEnterForeground(_:)), name: UIApplication.willEnterForegroundNotification, object: nil)
-
+  
     worker.enqueue {
       self._init()
     }
   }
   
-  deinit {
-      notificationCenter.removeObserver(self)
-  }
-
-  @objc private func appWillEnterForeground(_ notification: NSNotification) {
-    worker.enqueue {
-      self.switchToHardwareRendering()
-    }
-  }
-
-  @objc private func appWillResignActive(_ notification: NSNotification) {
-    if pipController == nil {
-      return
-    }
-    
-    if #available(iOS 14.2, *) {
-      if pipController!.canStartPictureInPictureAutomaticallyFromInline || pipController!.isPictureInPictureActive {
-        switchToSoftwareRendering()
-        return
-      }
-    } else if pipController!.isPictureInPictureActive {
-      switchToSoftwareRendering()
-      return
-    }
-    
-    var isPaused: Int8 = 0
-    mpv_get_property(handle, "pause", MPV_FORMAT_FLAG, &isPaused)
-    
-    if isPaused == 1 {
-      return
-    }
-
-    // Pause if apps goes into background and PiP is not enabled.
-    // Otherwise audio and video will continue playing.
-    mpv_command_string(handle, "cycle pause")
-  }
-
   public func switchToSoftwareRendering() {
     switchRendering(allowHardwareAcceleration: false)
   }
@@ -147,74 +99,6 @@ public class VideoOutput: NSObject, AVPictureInPictureSampleBufferPlaybackDelega
     mpv_set_property_string(handle, "vid", vid)
   }
 
-  public func refreshPlaybackState() {
-    if #available(iOS 15.0, *) {
-      pipController?.invalidatePlaybackState()
-    }
-  }
-
-  public func enablePictureInPicture() -> Bool {
-    if pipController != nil {
-      return true
-    }
-
-    if #available(iOS 15.0, *) {
-      bufferDisplayLayer.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
-      bufferDisplayLayer.opacity = 0
-      bufferDisplayLayer.videoGravity = .resizeAspect
-      
-      let contentSource = AVPictureInPictureController.ContentSource(sampleBufferDisplayLayer: bufferDisplayLayer, playbackDelegate: self)
-      pipController = AVPictureInPictureController(contentSource: contentSource)
-      pipController!.delegate = self
-      
-      // keyWindow is deprecated but currently flutter uses it internally just as well.
-      // See Flutter issue: https://github.com/flutter/flutter/issues/104117
-      let controller = UIApplication.shared.keyWindow?.rootViewController
-      // Add bufferDisplayLayer as an invisible layer to view to make PIP work.
-      controller?.view.layer.addSublayer(bufferDisplayLayer)
-      
-      return true
-    }
-    
-    return false
-  }
-  
-  public func disablePictureInPicture() {
-    if bufferDisplayLayer.superlayer != nil {
-      bufferDisplayLayer.removeFromSuperlayer()
-    }
-
-    pipController = nil
-  }
-
-  public func enableAutoPictureInPicture() -> Bool {
-    if enablePictureInPicture() {
-      if #available(iOS 14.2, *) {
-        pipController?.canStartPictureInPictureAutomaticallyFromInline = true
-        return true
-      }
-    }
-    
-    return false
-  }
-
-  public func disableAutoPictureInPicture() {
-    if pipController != nil {
-      if #available(iOS 14.2, *) {
-        pipController?.canStartPictureInPictureAutomaticallyFromInline = false
-      }
-    }
-  }
-  
-  public func enterPictureInPicture() -> Bool {
-    if enablePictureInPicture() {
-      pipController?.startPictureInPicture()
-      return true
-    }
-    
-    return false
-  }
-
   public func setSize(width: Int64?, height: Int64?) {
     worker.enqueue {
       self.userSetWidth = width
@@ -227,10 +111,27 @@ public class VideoOutput: NSObject, AVPictureInPictureSampleBufferPlaybackDelega
     self.width = width
     self.height = height
   }
+  
+  public func refreshPlaybackState() {}
+
+  func enablePictureInPicture() -> Bool {
+    return false
+  }
+  
+  public func disablePictureInPicture() {}
+
+  public func enableAutoPictureInPicture() -> Bool {
+    return false
+  }
+
+  public func disableAutoPictureInPicture() {}
+  
+  public func enterPictureInPicture() -> Bool {
+    return false
+  }
+  
 
   public func dispose() {
-    disablePictureInPicture()
-    
     worker.enqueue {
       self._dispose()
     }
@@ -285,7 +186,7 @@ public class VideoOutput: NSObject, AVPictureInPictureSampleBufferPlaybackDelega
     }
   }
 
-  private func _updateCallback() {
+  fileprivate func _updateCallback() {
     let width = videoWidth
     let height = videoHeight
 
@@ -312,33 +213,6 @@ public class VideoOutput: NSObject, AVPictureInPictureSampleBufferPlaybackDelega
 
     texture.render(size)
 
-    if pipController != nil {
-      let pixelBuffer = texture.copyPixelBuffer()?.takeUnretainedValue()
-      if pixelBuffer == nil {
-        return
-      }
-
-      var sampleBuffer: CMSampleBuffer?
-      
-      if videoFormat == nil || !CMVideoFormatDescriptionMatchesImageBuffer(videoFormat!, imageBuffer: pixelBuffer!)  {
-        videoFormat = nil
-        
-        let err = CMVideoFormatDescriptionCreateForImageBuffer(allocator: kCFAllocatorDefault, imageBuffer: pixelBuffer!, formatDescriptionOut: &videoFormat)
-        if (err != noErr) {
-          NSLog("Error at CMVideoFormatDescriptionCreateForImageBuffer \(err)")
-        }
-      }
-      
-      var sampleTimingInfo = CMSampleTimingInfo(duration: .invalid, presentationTimeStamp: CMTime(seconds: CACurrentMediaTime(), preferredTimescale: 100), decodeTimeStamp: .invalid)
-      
-      let err = CMSampleBufferCreateForImageBuffer(allocator: nil, imageBuffer: pixelBuffer!, dataReady: true, makeDataReadyCallback: nil, refcon: nil, formatDescription: videoFormat!, sampleTiming: &sampleTimingInfo, sampleBufferOut: &sampleBuffer)
-      if err == noErr {
-        bufferDisplayLayer.enqueue(sampleBuffer!)
-      } else {
-        NSLog("Error at CMSampleBufferCreateForImageBuffer \(err)")
-      }
-    }
-    
     registry.textureFrameAvailable(textureId)
   }
 
@@ -364,6 +238,154 @@ public class VideoOutput: NSObject, AVPictureInPictureSampleBufferPlaybackDelega
     mpv_get_property(handle, "height", MPV_FORMAT_INT64, &height)
 
     return height
+  }
+}
+
+#if os(iOS)
+@available(iOS 15.0, *)
+public class VideoOutputWithPIP: VideoOutput, AVPictureInPictureSampleBufferPlaybackDelegate, AVPictureInPictureControllerDelegate {
+  private var bufferDisplayLayer: AVSampleBufferDisplayLayer = AVSampleBufferDisplayLayer()
+  private var pipController: AVPictureInPictureController? = nil
+  private var videoFormat: CMVideoFormatDescription? = nil
+  private var notificationCenter: NotificationCenter {
+      return .default
+  }
+  
+  override init(handle: Int64, width: Int64?, height: Int64?, enableHardwareAcceleration: Bool, registry: FlutterTextureRegistry, textureUpdateCallback: @escaping VideoOutput.TextureUpdateCallback) {
+    super.init(handle: handle, width: width, height: height, enableHardwareAcceleration: enableHardwareAcceleration, registry: registry, textureUpdateCallback: textureUpdateCallback)
+    
+    notificationCenter.addObserver(self, selector: #selector(appWillResignActive(_:)), name: UIApplication.willResignActiveNotification, object: nil)
+    notificationCenter.addObserver(self, selector: #selector(appWillEnterForeground(_:)), name: UIApplication.willEnterForegroundNotification, object: nil)
+  }
+  
+  deinit {
+    notificationCenter.removeObserver(self)
+  }
+  
+  @objc private func appWillEnterForeground(_ notification: NSNotification) {
+    worker.enqueue {
+      self.switchToHardwareRendering()
+    }
+  }
+  
+  @objc private func appWillResignActive(_ notification: NSNotification) {
+    if pipController == nil {
+      return
+    }
+    
+    if pipController!.canStartPictureInPictureAutomaticallyFromInline || pipController!.isPictureInPictureActive {
+      switchToSoftwareRendering()
+      return
+    }
+    
+    var isPaused: Int8 = 0
+    mpv_get_property(handle, "pause", MPV_FORMAT_FLAG, &isPaused)
+    
+    if isPaused == 1 {
+      return
+    }
+    
+    // Pause if apps goes into background and PiP is not enabled.
+    // Otherwise audio and video will continue playing.
+    mpv_command_string(handle, "cycle pause")
+  }
+  
+  override public func refreshPlaybackState() {
+    pipController?.invalidatePlaybackState()
+  }
+  
+  override public func enablePictureInPicture() -> Bool {
+    if pipController != nil {
+      return true
+    }
+    
+    bufferDisplayLayer.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
+    bufferDisplayLayer.opacity = 0
+    bufferDisplayLayer.videoGravity = .resizeAspect
+    
+    let contentSource = AVPictureInPictureController.ContentSource(sampleBufferDisplayLayer: bufferDisplayLayer, playbackDelegate: self)
+    pipController = AVPictureInPictureController(contentSource: contentSource)
+    pipController!.delegate = self
+    
+    // keyWindow is deprecated but currently flutter uses it internally just as well.
+    // See Flutter issue: https://github.com/flutter/flutter/issues/104117
+    let controller = UIApplication.shared.keyWindow?.rootViewController
+    // Add bufferDisplayLayer as an invisible layer to view to make PIP work.
+    controller?.view.layer.addSublayer(bufferDisplayLayer)
+    
+    return true
+  }
+  
+  override public func disablePictureInPicture() {
+    if bufferDisplayLayer.superlayer != nil {
+      bufferDisplayLayer.removeFromSuperlayer()
+    }
+    
+    pipController = nil
+  }
+  
+  override public func enableAutoPictureInPicture() -> Bool {
+#if os(iOS)
+    if enablePictureInPicture() {
+      pipController?.canStartPictureInPictureAutomaticallyFromInline = true
+      return true
+    }
+#endif
+    
+    return false
+  }
+  
+  override public func disableAutoPictureInPicture() {
+#if os(iOS)
+    if pipController != nil {
+      pipController?.canStartPictureInPictureAutomaticallyFromInline = false
+    }
+#endif
+  }
+  
+  override public func enterPictureInPicture() -> Bool {
+    if enablePictureInPicture() {
+      pipController?.startPictureInPicture()
+      return true
+    }
+    
+    return false
+  }
+  
+  override func _updateCallback() {
+    super._updateCallback()
+    
+    if pipController != nil {
+      let pixelBuffer = texture.copyPixelBuffer()?.takeUnretainedValue()
+      if pixelBuffer == nil {
+        return
+      }
+      
+      var sampleBuffer: CMSampleBuffer?
+      
+      if videoFormat == nil || !CMVideoFormatDescriptionMatchesImageBuffer(videoFormat!, imageBuffer: pixelBuffer!)  {
+        videoFormat = nil
+        
+        let err = CMVideoFormatDescriptionCreateForImageBuffer(allocator: kCFAllocatorDefault, imageBuffer: pixelBuffer!, formatDescriptionOut: &videoFormat)
+        if (err != noErr) {
+          NSLog("Error at CMVideoFormatDescriptionCreateForImageBuffer \(err)")
+        }
+      }
+      
+      var sampleTimingInfo = CMSampleTimingInfo(duration: .invalid, presentationTimeStamp: CMTime(seconds: CACurrentMediaTime(), preferredTimescale: 100), decodeTimeStamp: .invalid)
+      
+      let err = CMSampleBufferCreateForImageBuffer(allocator: nil, imageBuffer: pixelBuffer!, dataReady: true, makeDataReadyCallback: nil, refcon: nil, formatDescription: videoFormat!, sampleTiming: &sampleTimingInfo, sampleBufferOut: &sampleBuffer)
+      if err == noErr {
+        bufferDisplayLayer.enqueue(sampleBuffer!)
+      } else {
+        NSLog("Error at CMSampleBufferCreateForImageBuffer \(err)")
+      }
+    }
+  }
+  
+  public override func dispose() {
+    super.dispose()
+    disablePictureInPicture()
   }
 
   public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, setPlaying playing: Bool) {
@@ -429,3 +451,4 @@ public class VideoOutput: NSObject, AVPictureInPictureSampleBufferPlaybackDelega
     self.setSize(width: userSetWidth, height: userSetHeight)
   }
 }
+#endif

--- a/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
@@ -4,13 +4,17 @@
   import FlutterMacOS
 #endif
 
+import AVKit
+import AVFoundation
+import UIKit
+
 // This class creates and manipulates the different types of FlutterTexture,
 // handles resizing, rendering calls, and notify Flutter when a new frame is
 // available to render.
 //
 // To improve the user experience, a worker is used to execute heavy tasks on a
 // dedicated thread.
-public class VideoOutput: NSObject {
+public class VideoOutput: NSObject, AVPictureInPictureSampleBufferPlaybackDelegate, AVPictureInPictureControllerDelegate {
   public typealias TextureUpdateCallback = (Int64, CGSize) -> Void
 
   private static let isSimulator: Bool = {
@@ -25,16 +29,27 @@ public class VideoOutput: NSObject {
 
   private let handle: OpaquePointer
   private let enableHardwareAcceleration: Bool
+  private var usingHardwareAcceleration: Bool
   private let registry: FlutterTextureRegistry
   private let textureUpdateCallback: TextureUpdateCallback
   private let worker: Worker = .init()
   private var width: Int64?
   private var height: Int64?
+  private var userSetWidth: Int64?
+  private var userSetHeight: Int64?
   private var texture: ResizableTextureProtocol!
   private var textureId: Int64 = -1
   private var currentWidth: Int64 = 0
   private var currentHeight: Int64 = 0
   private var disposed: Bool = false
+
+  private let pipAvailable: Bool
+  private var bufferDisplayLayer: AVSampleBufferDisplayLayer = AVSampleBufferDisplayLayer()
+  private var pipController: AVPictureInPictureController? = nil
+  private var videoFormat: CMVideoFormatDescription? = nil
+  private var notificationCenter: NotificationCenter {
+      return .default
+  }
 
   init(
     handle: Int64,
@@ -42,7 +57,8 @@ public class VideoOutput: NSObject {
     height: Int64?,
     enableHardwareAcceleration: Bool,
     registry: FlutterTextureRegistry,
-    textureUpdateCallback: @escaping TextureUpdateCallback
+    textureUpdateCallback: @escaping TextureUpdateCallback,
+    pipAvailable: Bool
   ) {
     let handle = OpaquePointer(bitPattern: Int(handle))
     assert(handle != nil, "handle casting")
@@ -50,25 +66,171 @@ public class VideoOutput: NSObject {
     self.handle = handle!
     self.width = width
     self.height = height
-    self.enableHardwareAcceleration = enableHardwareAcceleration
+    self.enableHardwareAcceleration = VideoOutput.isSimulator ? false : enableHardwareAcceleration
+    self.usingHardwareAcceleration = self.enableHardwareAcceleration
     self.registry = registry
     self.textureUpdateCallback = textureUpdateCallback
+    self.pipAvailable = pipAvailable
 
     super.init()
+    
+    notificationCenter.addObserver(self, selector: #selector(appWillResignActive(_:)), name: UIApplication.willResignActiveNotification, object: nil)
+    notificationCenter.addObserver(self, selector: #selector(appWillEnterForeground(_:)), name: UIApplication.willEnterForegroundNotification, object: nil)
 
     worker.enqueue {
       self._init()
     }
   }
+  
+  deinit {
+      notificationCenter.removeObserver(self)
+  }
 
-  public func setSize(width: Int64?, height: Int64?) {
+  @objc private func appWillEnterForeground(_ notification: NSNotification) {
     worker.enqueue {
-      self.width = width
-      self.height = height
+      self.switchToHardwareRendering()
     }
   }
 
+  @objc private func appWillResignActive(_ notification: NSNotification) {
+    if pipController == nil {
+      return
+    }
+    
+    if #available(iOS 14.2, *) {
+      if pipController!.canStartPictureInPictureAutomaticallyFromInline || pipController!.isPictureInPictureActive {
+        switchToSoftwareRendering()
+        return
+      }
+    } else if pipController!.isPictureInPictureActive {
+      switchToSoftwareRendering()
+      return
+    }
+    
+    var isPaused: Int8 = 0
+    mpv_get_property(handle, "pause", MPV_FORMAT_FLAG, &isPaused)
+    
+    if isPaused == 1 {
+      return
+    }
+
+    // Pause if apps goes into background and PiP is not enabled.
+    // Otherwise audio and video will continue playing.
+    mpv_command_string(handle, "cycle pause")
+  }
+
+  public func switchToSoftwareRendering() {
+    switchRendering(allowHardwareAcceleration: false)
+  }
+  
+  public func switchToHardwareRendering() {
+    switchRendering(allowHardwareAcceleration: true)
+  }
+
+  public func switchRendering(allowHardwareAcceleration: Bool) {
+    if !enableHardwareAcceleration || allowHardwareAcceleration == usingHardwareAcceleration {
+      return
+    }
+    
+    usingHardwareAcceleration = allowHardwareAcceleration
+
+    NSLog("switchRendering allowHardwareAcceleration: \(allowHardwareAcceleration)")
+    let vid = mpv_get_property_string(handle, "vid")
+    mpv_set_property_string(handle, "vid", "no")
+
+    texture.dispose()
+    disposeTextureId()
+    currentWidth = 0
+    currentHeight = 0
+    _init(allowHardwareAcceleration: allowHardwareAcceleration)
+
+    mpv_set_property_string(handle, "vid", vid)
+  }
+
+  public func refreshPlaybackState() {
+    if #available(iOS 15.0, *) {
+      pipController?.invalidatePlaybackState()
+    }
+  }
+
+  public func enablePictureInPicture() -> Bool {
+    if pipController != nil {
+      return true
+    }
+
+    if #available(iOS 15.0, *) {
+      bufferDisplayLayer.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
+      bufferDisplayLayer.opacity = 0
+      bufferDisplayLayer.videoGravity = .resizeAspect
+      
+      let contentSource = AVPictureInPictureController.ContentSource(sampleBufferDisplayLayer: bufferDisplayLayer, playbackDelegate: self)
+      pipController = AVPictureInPictureController(contentSource: contentSource)
+      pipController!.delegate = self
+      
+      // keyWindow is deprecated but currently flutter uses it internally just as well.
+      // See Flutter issue: https://github.com/flutter/flutter/issues/104117
+      let controller = UIApplication.shared.keyWindow?.rootViewController
+      // Add bufferDisplayLayer as an invisible layer to view to make PIP work.
+      controller?.view.layer.addSublayer(bufferDisplayLayer)
+      
+      return true
+    }
+    
+    return false
+  }
+  
+  public func disablePictureInPicture() {
+    if bufferDisplayLayer.superlayer != nil {
+      bufferDisplayLayer.removeFromSuperlayer()
+    }
+
+    pipController = nil
+  }
+
+  public func enableAutoPictureInPicture() -> Bool {
+    if enablePictureInPicture() {
+      if #available(iOS 14.2, *) {
+        pipController?.canStartPictureInPictureAutomaticallyFromInline = true
+        return true
+      }
+    }
+    
+    return false
+  }
+
+  public func disableAutoPictureInPicture() {
+    if pipController != nil {
+      if #available(iOS 14.2, *) {
+        pipController?.canStartPictureInPictureAutomaticallyFromInline = false
+      }
+    }
+  }
+  
+  public func enterPictureInPicture() -> Bool {
+    if enablePictureInPicture() {
+      pipController?.startPictureInPicture()
+      return true
+    }
+    
+    return false
+  }
+
+  public func setSize(width: Int64?, height: Int64?) {
+    worker.enqueue {
+      self.userSetWidth = width
+      self.userSetHeight = height
+      self._setTextureSize(width: width, height: height)
+    }
+  }
+
+  public func _setTextureSize(width: Int64?, height: Int64?) {
+    self.width = width
+    self.height = height
+  }
+
   public func dispose() {
+    disablePictureInPicture()
+    
     worker.enqueue {
       self._dispose()
     }
@@ -81,12 +243,9 @@ public class VideoOutput: NSObject {
     texture.dispose()
   }
 
-  private func _init() {
-    let enableHardwareAcceleration =
-      VideoOutput.isSimulator ? false : enableHardwareAcceleration
-
+  private func _init(allowHardwareAcceleration: Bool = true) {
     NSLog(
-      "VideoOutput: enableHardwareAcceleration: \(enableHardwareAcceleration)"
+      "VideoOutput: enableHardwareAcceleration: \(enableHardwareAcceleration) allowHardwareAcceleration: \(allowHardwareAcceleration)"
     )
 
     if VideoOutput.isSimulator {
@@ -95,7 +254,7 @@ public class VideoOutput: NSObject {
       )
     }
 
-    if enableHardwareAcceleration {
+    if enableHardwareAcceleration && allowHardwareAcceleration {
       texture = SafeResizableTexture(
         TextureHW(
           handle: handle,
@@ -152,6 +311,34 @@ public class VideoOutput: NSObject {
     }
 
     texture.render(size)
+
+    if pipController != nil {
+      let pixelBuffer = texture.copyPixelBuffer()?.takeUnretainedValue()
+      if pixelBuffer == nil {
+        return
+      }
+
+      var sampleBuffer: CMSampleBuffer?
+      
+      if videoFormat == nil || !CMVideoFormatDescriptionMatchesImageBuffer(videoFormat!, imageBuffer: pixelBuffer!)  {
+        videoFormat = nil
+        
+        let err = CMVideoFormatDescriptionCreateForImageBuffer(allocator: kCFAllocatorDefault, imageBuffer: pixelBuffer!, formatDescriptionOut: &videoFormat)
+        if (err != noErr) {
+          NSLog("Error at CMVideoFormatDescriptionCreateForImageBuffer \(err)")
+        }
+      }
+      
+      var sampleTimingInfo = CMSampleTimingInfo(duration: .invalid, presentationTimeStamp: CMTime(seconds: CACurrentMediaTime(), preferredTimescale: 100), decodeTimeStamp: .invalid)
+      
+      let err = CMSampleBufferCreateForImageBuffer(allocator: nil, imageBuffer: pixelBuffer!, dataReady: true, makeDataReadyCallback: nil, refcon: nil, formatDescription: videoFormat!, sampleTiming: &sampleTimingInfo, sampleBufferOut: &sampleBuffer)
+      if err == noErr {
+        bufferDisplayLayer.enqueue(sampleBuffer!)
+      } else {
+        NSLog("Error at CMSampleBufferCreateForImageBuffer \(err)")
+      }
+    }
+    
     registry.textureFrameAvailable(textureId)
   }
 
@@ -177,5 +364,68 @@ public class VideoOutput: NSObject {
     mpv_get_property(handle, "height", MPV_FORMAT_INT64, &height)
 
     return height
+  }
+
+  public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, setPlaying playing: Bool) {
+    var isPaused: Int8 = 0
+    mpv_get_property(handle, "pause", MPV_FORMAT_FLAG, &isPaused)
+    
+    if playing == (isPaused == 0) {
+      return
+    }
+
+    mpv_command_string(handle, "cycle pause")
+  }
+
+  public func pictureInPictureControllerTimeRangeForPlayback(_ pictureInPictureController: AVPictureInPictureController) -> CMTimeRange {
+    var position: Double = 0
+    mpv_get_property(handle, "time-pos", MPV_FORMAT_DOUBLE, &position)
+
+    var duration: Double = 0
+    mpv_get_property(handle, "duration", MPV_FORMAT_DOUBLE, &duration)
+    
+    return CMTimeRange(
+      start:  CMTime(
+        seconds: CACurrentMediaTime() - position,
+        preferredTimescale: 100
+      ),
+      duration: CMTime(
+        seconds: duration,
+        preferredTimescale: 100
+      )
+    )
+  }
+
+  public func pictureInPictureControllerIsPlaybackPaused(_ pictureInPictureController: AVPictureInPictureController) -> Bool {
+    var isPaused: Int8 = 0
+    mpv_get_property(handle, "pause", MPV_FORMAT_FLAG, &isPaused)
+    
+    return isPaused == 1
+  }
+
+  public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, didTransitionToRenderSize newRenderSize: CMVideoDimensions) {
+    NSLog("Resize texture due to PIP new size: \(newRenderSize)")
+
+    worker.enqueue {
+      if newRenderSize.width == 0 || newRenderSize.height == 0 {
+        self._setTextureSize(width: nil, height: nil)
+      } else {
+        self._setTextureSize(width: Int64(CGFloat(newRenderSize.width) * UIScreen.main.scale),
+                             height: Int64(CGFloat(newRenderSize.height) * UIScreen.main.scale))
+      }
+    }
+  }
+
+  public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, skipByInterval skipInterval: CMTime, completion completionHandler: @escaping () -> Void) {
+    mpv_command_string(handle, "seek \(skipInterval.seconds)")
+    completionHandler()
+  }
+
+  public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, failedToStartPictureInPictureWithError error: Error) {
+    NSLog("pictureInPictureController error: \(error)")
+  }
+  
+  public func pictureInPictureControllerWillStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+    self.setSize(width: userSetWidth, height: userSetHeight)
   }
 }

--- a/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/VideoOutput.swift
@@ -325,22 +325,18 @@ public class VideoOutputWithPIP: VideoOutput, AVPictureInPictureSampleBufferPlay
   }
   
   override public func enableAutoPictureInPicture() -> Bool {
-#if os(iOS)
     if enablePictureInPicture() {
       pipController?.canStartPictureInPictureAutomaticallyFromInline = true
       return true
     }
-#endif
     
     return false
   }
   
   override public func disableAutoPictureInPicture() {
-#if os(iOS)
     if pipController != nil {
       pipController?.canStartPictureInPictureAutomaticallyFromInline = false
     }
-#endif
   }
   
   override public func enterPictureInPicture() -> Bool {

--- a/media_kit_video/common/darwin/Classes/plugin/VideoOutputManager.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/VideoOutputManager.swift
@@ -30,7 +30,7 @@ public class VideoOutputManager: NSObject {
   ) {
     #if os(iOS)
     if #available(iOS 15.0, *) {
-      let videoOutput = VideoOutputWithPIP(
+      let videoOutput = VideoOutputPIP(
         handle: handle,
         configuration: configuration,
         registry: self.registry,

--- a/media_kit_video/common/darwin/Classes/plugin/VideoOutputManager.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/VideoOutputManager.swift
@@ -4,12 +4,27 @@
   import FlutterMacOS
 #endif
 
+import AVKit
+import AVFoundation
+import UIKit
+
 public class VideoOutputManager: NSObject {
   private let registry: FlutterTextureRegistry
   private var videoOutputs = [Int64: VideoOutput]()
 
+  private let pipAvailable: Bool
+
   init(registry: FlutterTextureRegistry) {
     self.registry = registry
+
+    // AVPictureInPictureController.ContentSource is available only since iOS 15+
+    if #available(iOS 15.0, *) {
+      pipAvailable = true
+    } else {
+      pipAvailable = false
+    }
+
+    super.init()
   }
 
   public func create(
@@ -25,7 +40,8 @@ public class VideoOutputManager: NSObject {
       height: height,
       enableHardwareAcceleration: enableHardwareAcceleration,
       registry: self.registry,
-      textureUpdateCallback: textureUpdateCallback
+      textureUpdateCallback: textureUpdateCallback,
+      pipAvailable: pipAvailable
     )
 
     self.videoOutputs[handle] = videoOutput
@@ -47,6 +63,76 @@ public class VideoOutputManager: NSObject {
     )
   }
 
+  public func isPictureInPictureAvailable() -> Bool {
+    return pipAvailable
+  }
+
+  public func enablePictureInPicture(
+    handle: Int64
+  ) -> Bool {
+    let videoOutput = self.videoOutputs[handle]
+    if videoOutput == nil {
+      return false
+    }
+
+    return videoOutput!.enablePictureInPicture()
+  }
+
+  public func disablePictureInPicture(
+    handle: Int64
+  ) {
+    let videoOutput = self.videoOutputs[handle]
+    if videoOutput == nil {
+      return
+    }
+
+    videoOutput!.disablePictureInPicture()
+  }
+
+  public func enableAutoPictureInPicture(
+    handle: Int64
+  ) -> Bool {
+    let videoOutput = self.videoOutputs[handle]
+    if videoOutput == nil {
+      return false
+    }
+
+    return videoOutput!.enableAutoPictureInPicture()
+  }
+
+  public func disableAutoPictureInPicture(
+    handle: Int64
+  ) {
+    let videoOutput = self.videoOutputs[handle]
+    if videoOutput == nil {
+      return
+    }
+
+    videoOutput!.disableAutoPictureInPicture()
+  }
+
+  public func enterPictureInPicture(
+    handle: Int64
+  ) -> Bool {
+    let videoOutput = self.videoOutputs[handle]
+    if videoOutput == nil {
+      return false
+    }
+
+    return videoOutput!.enterPictureInPicture()
+  }
+
+  public func refreshPlaybackState(
+    handle: Int64
+  ) {
+    let videoOutput = self.videoOutputs[handle]
+    if videoOutput == nil {
+      return
+    }
+
+    videoOutput!.refreshPlaybackState()
+  }
+  
   public func destroy(
     handle: Int64
   ) {

--- a/media_kit_video/common/darwin/Classes/plugin/VideoOutputManager.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/VideoOutputManager.swift
@@ -4,10 +4,6 @@
   import FlutterMacOS
 #endif
 
-import AVKit
-import AVFoundation
-import UIKit
-
 public class VideoOutputManager: NSObject {
   private let registry: FlutterTextureRegistry
   private var videoOutputs = [Int64: VideoOutput]()
@@ -34,14 +30,29 @@ public class VideoOutputManager: NSObject {
     enableHardwareAcceleration: Bool,
     textureUpdateCallback: @escaping VideoOutput.TextureUpdateCallback
   ) {
+    #if os(iOS)
+    if #available(iOS 15.0, *) {
+      let videoOutput = VideoOutputWithPIP(
+        handle: handle,
+        width: width,
+        height: height,
+        enableHardwareAcceleration: enableHardwareAcceleration,
+        registry: self.registry,
+        textureUpdateCallback: textureUpdateCallback
+      )
+      self.videoOutputs[handle] = videoOutput
+      
+      return
+    }
+    #endif
+
     let videoOutput = VideoOutput(
       handle: handle,
       width: width,
       height: height,
       enableHardwareAcceleration: enableHardwareAcceleration,
       registry: self.registry,
-      textureUpdateCallback: textureUpdateCallback,
-      pipAvailable: pipAvailable
+      textureUpdateCallback: textureUpdateCallback
     )
 
     self.videoOutputs[handle] = videoOutput

--- a/media_kit_video/common/darwin/Classes/plugin/VideoOutputPIP.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/VideoOutputPIP.swift
@@ -69,6 +69,12 @@ public class VideoOutputPIP: VideoOutput, AVPictureInPictureSampleBufferPlayback
       return true
     }
     
+    do {
+      try AVAudioSession.sharedInstance().setCategory(.playback)
+    } catch {
+      NSLog("AVAudioSession set category failed")
+    }
+    
     bufferDisplayLayer.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
     bufferDisplayLayer.opacity = 0
     bufferDisplayLayer.videoGravity = .resizeAspect
@@ -192,16 +198,7 @@ public class VideoOutputPIP: VideoOutput, AVPictureInPictureSampleBufferPlayback
   }
   
   public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, didTransitionToRenderSize newRenderSize: CMVideoDimensions) {
-    NSLog("Resize texture due to PIP new size: \(newRenderSize)")
-    
-    worker.enqueue {
-      if newRenderSize.width == 0 || newRenderSize.height == 0 {
-        self._setTextureSize(width: nil, height: nil)
-      } else {
-        self._setTextureSize(width: Int64(CGFloat(newRenderSize.width) * UIScreen.main.scale),
-                             height: Int64(CGFloat(newRenderSize.height) * UIScreen.main.scale))
-      }
-    }
+    // Downscaling texture actually causes more performance issues here on SW renderer.
   }
   
   public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, skipByInterval skipInterval: CMTime, completion completionHandler: @escaping () -> Void) {
@@ -214,7 +211,6 @@ public class VideoOutputPIP: VideoOutput, AVPictureInPictureSampleBufferPlayback
   }
   
   public func pictureInPictureControllerWillStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
-    self.setSize(width: userSetWidth, height: userSetHeight)
   }
 }
 #endif

--- a/media_kit_video/common/darwin/Classes/plugin/VideoOutputPIP.swift
+++ b/media_kit_video/common/darwin/Classes/plugin/VideoOutputPIP.swift
@@ -1,0 +1,220 @@
+#if canImport(Flutter)
+import Flutter
+#elseif canImport(FlutterMacOS)
+import FlutterMacOS
+#endif
+
+import AVKit
+
+#if os(iOS)
+import UIKit
+#endif
+
+
+#if os(iOS)
+@available(iOS 15.0, *)
+public class VideoOutputPIP: VideoOutput, AVPictureInPictureSampleBufferPlaybackDelegate, AVPictureInPictureControllerDelegate {
+  private var bufferDisplayLayer: AVSampleBufferDisplayLayer = AVSampleBufferDisplayLayer()
+  private var pipController: AVPictureInPictureController? = nil
+  private var videoFormat: CMVideoFormatDescription? = nil
+  private var notificationCenter: NotificationCenter {
+    return .default
+  }
+  
+  override init(handle: Int64, configuration: VideoOutputConfiguration, registry: FlutterTextureRegistry, textureUpdateCallback: @escaping VideoOutput.TextureUpdateCallback) {
+    super.init(handle: handle, configuration: configuration, registry: registry, textureUpdateCallback: textureUpdateCallback)
+    
+    notificationCenter.addObserver(self, selector: #selector(appWillResignActive(_:)), name: UIApplication.willResignActiveNotification, object: nil)
+    notificationCenter.addObserver(self, selector: #selector(appWillEnterForeground(_:)), name: UIApplication.willEnterForegroundNotification, object: nil)
+  }
+  
+  deinit {
+    notificationCenter.removeObserver(self)
+  }
+  
+  @objc private func appWillEnterForeground(_ notification: NSNotification) {
+    worker.enqueue {
+      self.switchToHardwareRendering()
+    }
+  }
+  
+  @objc private func appWillResignActive(_ notification: NSNotification) {
+    if pipController == nil {
+      return
+    }
+    
+    if pipController!.canStartPictureInPictureAutomaticallyFromInline || pipController!.isPictureInPictureActive {
+      switchToSoftwareRendering()
+      return
+    }
+    
+    var isPaused: Int8 = 0
+    mpv_get_property(handle, "pause", MPV_FORMAT_FLAG, &isPaused)
+    
+    if isPaused == 1 {
+      return
+    }
+    
+    // Pause if apps goes into background and PiP is not enabled.
+    // Otherwise audio and video will continue playing.
+    mpv_command_string(handle, "cycle pause")
+  }
+  
+  override public func refreshPlaybackState() {
+    pipController?.invalidatePlaybackState()
+  }
+  
+  override public func enablePictureInPicture() -> Bool {
+    if pipController != nil {
+      return true
+    }
+    
+    bufferDisplayLayer.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
+    bufferDisplayLayer.opacity = 0
+    bufferDisplayLayer.videoGravity = .resizeAspect
+    
+    let contentSource = AVPictureInPictureController.ContentSource(sampleBufferDisplayLayer: bufferDisplayLayer, playbackDelegate: self)
+    pipController = AVPictureInPictureController(contentSource: contentSource)
+    pipController!.delegate = self
+    
+    // keyWindow is deprecated but currently flutter uses it internally just as well.
+    // See Flutter issue: https://github.com/flutter/flutter/issues/104117
+    let controller = UIApplication.shared.keyWindow?.rootViewController
+    // Add bufferDisplayLayer as an invisible layer to view to make PIP work.
+    controller?.view.layer.addSublayer(bufferDisplayLayer)
+    
+    return true
+  }
+  
+  override public func disablePictureInPicture() {
+    if bufferDisplayLayer.superlayer != nil {
+      bufferDisplayLayer.removeFromSuperlayer()
+    }
+    
+    pipController = nil
+  }
+  
+  override public func enableAutoPictureInPicture() -> Bool {
+    if enablePictureInPicture() {
+      pipController?.canStartPictureInPictureAutomaticallyFromInline = true
+      return true
+    }
+    
+    return false
+  }
+  
+  override public func disableAutoPictureInPicture() {
+    if pipController != nil {
+      pipController?.canStartPictureInPictureAutomaticallyFromInline = false
+    }
+  }
+  
+  override public func enterPictureInPicture() -> Bool {
+    if enablePictureInPicture() {
+      pipController?.startPictureInPicture()
+      return true
+    }
+    
+    return false
+  }
+  
+  override func _updateCallback() {
+    super._updateCallback()
+    
+    if pipController != nil {
+      let pixelBuffer = texture.copyPixelBuffer()?.takeUnretainedValue()
+      if pixelBuffer == nil {
+        return
+      }
+      
+      var sampleBuffer: CMSampleBuffer?
+      
+      if videoFormat == nil || !CMVideoFormatDescriptionMatchesImageBuffer(videoFormat!, imageBuffer: pixelBuffer!)  {
+        videoFormat = nil
+        
+        let err = CMVideoFormatDescriptionCreateForImageBuffer(allocator: kCFAllocatorDefault, imageBuffer: pixelBuffer!, formatDescriptionOut: &videoFormat)
+        if (err != noErr) {
+          NSLog("Error at CMVideoFormatDescriptionCreateForImageBuffer \(err)")
+        }
+      }
+      
+      var sampleTimingInfo = CMSampleTimingInfo(duration: .invalid, presentationTimeStamp: CMTime(seconds: CACurrentMediaTime(), preferredTimescale: 100), decodeTimeStamp: .invalid)
+      
+      let err = CMSampleBufferCreateForImageBuffer(allocator: nil, imageBuffer: pixelBuffer!, dataReady: true, makeDataReadyCallback: nil, refcon: nil, formatDescription: videoFormat!, sampleTiming: &sampleTimingInfo, sampleBufferOut: &sampleBuffer)
+      if err == noErr {
+        bufferDisplayLayer.enqueue(sampleBuffer!)
+      } else {
+        NSLog("Error at CMSampleBufferCreateForImageBuffer \(err)")
+      }
+    }
+  }
+  
+  public override func dispose() {
+    super.dispose()
+    disablePictureInPicture()
+  }
+  
+  public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, setPlaying playing: Bool) {
+    var isPaused: Int8 = 0
+    mpv_get_property(handle, "pause", MPV_FORMAT_FLAG, &isPaused)
+    
+    if playing == (isPaused == 0) {
+      return
+    }
+    
+    mpv_command_string(handle, "cycle pause")
+  }
+  
+  public func pictureInPictureControllerTimeRangeForPlayback(_ pictureInPictureController: AVPictureInPictureController) -> CMTimeRange {
+    var position: Double = 0
+    mpv_get_property(handle, "time-pos", MPV_FORMAT_DOUBLE, &position)
+    
+    var duration: Double = 0
+    mpv_get_property(handle, "duration", MPV_FORMAT_DOUBLE, &duration)
+    
+    return CMTimeRange(
+      start:  CMTime(
+        seconds: CACurrentMediaTime() - position,
+        preferredTimescale: 100
+      ),
+      duration: CMTime(
+        seconds: duration,
+        preferredTimescale: 100
+      )
+    )
+  }
+  
+  public func pictureInPictureControllerIsPlaybackPaused(_ pictureInPictureController: AVPictureInPictureController) -> Bool {
+    var isPaused: Int8 = 0
+    mpv_get_property(handle, "pause", MPV_FORMAT_FLAG, &isPaused)
+    
+    return isPaused == 1
+  }
+  
+  public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, didTransitionToRenderSize newRenderSize: CMVideoDimensions) {
+    NSLog("Resize texture due to PIP new size: \(newRenderSize)")
+    
+    worker.enqueue {
+      if newRenderSize.width == 0 || newRenderSize.height == 0 {
+        self._setTextureSize(width: nil, height: nil)
+      } else {
+        self._setTextureSize(width: Int64(CGFloat(newRenderSize.width) * UIScreen.main.scale),
+                             height: Int64(CGFloat(newRenderSize.height) * UIScreen.main.scale))
+      }
+    }
+  }
+  
+  public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, skipByInterval skipInterval: CMTime, completion completionHandler: @escaping () -> Void) {
+    mpv_command_string(handle, "seek \(skipInterval.seconds)")
+    completionHandler()
+  }
+  
+  public func pictureInPictureController(_ pictureInPictureController: AVPictureInPictureController, failedToStartPictureInPictureWithError error: Error) {
+    NSLog("pictureInPictureController error: \(error)")
+  }
+  
+  public func pictureInPictureControllerWillStopPictureInPicture(_ pictureInPictureController: AVPictureInPictureController) {
+    self.setSize(width: userSetWidth, height: userSetHeight)
+  }
+}
+#endif

--- a/media_kit_video/ios/Classes/plugin/TextureHW.swift
+++ b/media_kit_video/ios/Classes/plugin/TextureHW.swift
@@ -98,6 +98,7 @@ public class TextureHW: NSObject, FlutterTexture, ResizableTextureProtocol {
   }
 
   private func disposeMPV() {
+    mpv_render_context_set_update_callback(handle, nil, nil)
     mpv_render_context_free(renderContext)
   }
 

--- a/media_kit_video/ios/Classes/plugin/common/VideoOutputPIP.swift
+++ b/media_kit_video/ios/Classes/plugin/common/VideoOutputPIP.swift
@@ -1,0 +1,1 @@
+../../../../common/darwin/Classes/plugin/VideoOutputPIP.swift

--- a/media_kit_video/lib/src/video_controller/native_video_controller/real.dart
+++ b/media_kit_video/lib/src/video_controller/native_video_controller/real.dart
@@ -176,6 +176,10 @@ class NativeVideoController extends PlatformVideoController {
   /// Used to invalidate Picture in Picture view data.
   @override
   Future<void> refreshPlaybackState() async {
+    if (!Platform.isIOS) {
+      return;
+    }
+
     final handle = await player.handle;
     await _channel.invokeMethod(
       'VideoOutputManager.RefreshPlaybackState',
@@ -188,6 +192,10 @@ class NativeVideoController extends PlatformVideoController {
   /// Checks whether Picture in Picture is available on current platform.
   @override
   Future<bool> isPictureInPictureAvailable() async {
+    if (!Platform.isIOS) {
+      return false;
+    }
+
     final handle = await player.handle;
     return await _channel.invokeMethod(
       'VideoOutputManager.IsPictureInPictureAvailable',
@@ -198,6 +206,10 @@ class NativeVideoController extends PlatformVideoController {
   /// Enable Picture in Picture.
   /// Returns true if this is supported on current platofrm.
   Future<bool> enablePictureInPicture() async {
+    if (!Platform.isIOS) {
+      return false;
+    }
+
     final handle = await player.handle;
     return await _channel.invokeMethod(
       'VideoOutputManager.EnablePictureInPicture',
@@ -209,6 +221,10 @@ class NativeVideoController extends PlatformVideoController {
 
   /// Disable Picture in Picture.
   Future<void> disablePictureInPicture() async {
+    if (!Platform.isIOS) {
+      return;
+    }
+
     final handle = await player.handle;
     return await _channel.invokeMethod(
       'VideoOutputManager.DisablePictureInPicture',
@@ -222,6 +238,10 @@ class NativeVideoController extends PlatformVideoController {
   /// Returns true if this is supported on current platofrm.
   @override
   Future<bool> enableAutoPictureInPicture() async {
+    if (!Platform.isIOS) {
+      return false;
+    }
+
     final handle = await player.handle;
     return await _channel.invokeMethod(
       'VideoOutputManager.EnableAutoPictureInPicture',
@@ -234,6 +254,10 @@ class NativeVideoController extends PlatformVideoController {
   /// Disables automatically entering Picture in Picture when app goes into background.
   @override
   Future<void> disableAutoPictureInPicture() async {
+    if (!Platform.isIOS) {
+      return;
+    }
+
     final handle = await player.handle;
     await _channel.invokeMethod(
       'VideoOutputManager.DisableAutoPictureInPicture',
@@ -246,6 +270,10 @@ class NativeVideoController extends PlatformVideoController {
   /// Enters Picture in Picture view for current video.
   @override
   Future<bool> enterPictureInPicture() async {
+    if (!Platform.isIOS) {
+      return false;
+    }
+
     final handle = await player.handle;
     return await _channel.invokeMethod(
       'VideoOutputManager.EnterPictureInPicture',

--- a/media_kit_video/lib/src/video_controller/native_video_controller/real.dart
+++ b/media_kit_video/lib/src/video_controller/native_video_controller/real.dart
@@ -31,6 +31,7 @@ class NativeVideoController extends PlatformVideoController {
       Platform.isLinux ||
       Platform.isMacOS ||
       Platform.isIOS;
+  bool playing = false;
 
   /// {@macro native_video_controller}
   NativeVideoController._(
@@ -38,7 +39,19 @@ class NativeVideoController extends PlatformVideoController {
     super.width,
     super.height,
     super.enableHardwareAcceleration,
-  );
+  ) {
+    player.streams.playing.listen((e) async {
+      refreshPlaybackState();
+    });
+
+    player.streams.duration.listen((e) async {
+      refreshPlaybackState();
+    });
+
+    player.streams.seek.listen((e) async {
+      refreshPlaybackState();
+    });
+  }
 
   /// {@macro native_video_controller}
   static Future<PlatformVideoController> create(
@@ -121,6 +134,89 @@ class NativeVideoController extends PlatformVideoController {
         'handle': handle.toString(),
         'width': width.toString(),
         'height': height.toString(),
+      },
+    );
+  }
+
+  /// Refreshes playback state (on play/pause, seek or duration change).
+  /// Used to invalidate Picture in Picture view data.
+  @override
+  Future<void> refreshPlaybackState() async {
+    final handle = await player.handle;
+    await _channel.invokeMethod(
+      'VideoOutputManager.RefreshPlaybackState',
+      {
+        'handle': handle.toString(),
+      },
+    );
+  }
+
+  /// Checks whether Picture in Picture is available on current platform.
+  @override
+  Future<bool> isPictureInPictureAvailable() async {
+    final handle = await player.handle;
+    return await _channel.invokeMethod(
+      'VideoOutputManager.IsPictureInPictureAvailable',
+      {},
+    );
+  }
+
+  /// Enable Picture in Picture.
+  /// Returns true if this is supported on current platofrm.
+  Future<bool> enablePictureInPicture() async {
+    final handle = await player.handle;
+    return await _channel.invokeMethod(
+      'VideoOutputManager.EnablePictureInPicture',
+      {
+        'handle': handle.toString(),
+      },
+    );
+  }
+
+  /// Disable Picture in Picture.
+  Future<void> disablePictureInPicture() async {
+    final handle = await player.handle;
+    return await _channel.invokeMethod(
+      'VideoOutputManager.DisablePictureInPicture',
+      {
+        'handle': handle.toString(),
+      },
+    );
+  }
+
+  /// Enable automatically entering Picture in Picture when app goes into background.
+  /// Returns true if this is supported on current platofrm.
+  @override
+  Future<bool> enableAutoPictureInPicture() async {
+    final handle = await player.handle;
+    return await _channel.invokeMethod(
+      'VideoOutputManager.EnableAutoPictureInPicture',
+      {
+        'handle': handle.toString(),
+      },
+    );
+  }
+
+  /// Disables automatically entering Picture in Picture when app goes into background.
+  @override
+  Future<void> disableAutoPictureInPicture() async {
+    final handle = await player.handle;
+    await _channel.invokeMethod(
+      'VideoOutputManager.DisableAutoPictureInPicture',
+      {
+        'handle': handle.toString(),
+      },
+    );
+  }
+
+  /// Enters Picture in Picture view for current video.
+  @override
+  Future<bool> enterPictureInPicture() async {
+    final handle = await player.handle;
+    return await _channel.invokeMethod(
+      'VideoOutputManager.EnterPictureInPicture',
+      {
+        'handle': handle.toString(),
       },
     );
   }

--- a/media_kit_video/lib/src/video_controller/platform_video_controller.dart
+++ b/media_kit_video/lib/src/video_controller/platform_video_controller.dart
@@ -56,6 +56,42 @@ abstract class PlatformVideoController {
     int? height,
   });
 
+  /// Refreshes playback state (on play/pause, seek or duration change).
+  /// Used to invalidate Picture in Picture view data.
+  Future<void> refreshPlaybackState() async {
+    return;
+  }
+
+  /// Checks whether Picture in Picture is available on current platform.
+  Future<bool> isPictureInPictureAvailable() async {
+    return false;
+  }
+
+  /// Enable Picture in Picture.
+  /// Returns true if this is supported on current platofrm.
+  Future<bool> enablePictureInPicture() async {
+    return false;
+  }
+
+  /// Disable Picture in Picture.
+  Future<void> disablePictureInPicture() async {}
+
+  /// Enable automatically entering Picture in Picture when app goes into background.
+  /// Returns true if this is supported on current platofrm.
+  Future<bool> enableAutoPictureInPicture() async {
+    return false;
+  }
+
+  /// Disables automatically entering Picture in Picture when app goes into background.
+  Future<void> disableAutoPictureInPicture() async {
+    return;
+  }
+
+  /// Enters Picture in Picture view for current video.
+  Future<bool> enterPictureInPicture() async {
+    return false;
+  }
+
   @override
   String toString() => 'VideoController('
       'player: $player, '

--- a/media_kit_video/lib/src/video_controller/video_controller.dart
+++ b/media_kit_video/lib/src/video_controller/video_controller.dart
@@ -53,6 +53,8 @@ class VideoController {
   /// [Rect] of the video output, received from the native implementation.
   final ValueNotifier<Rect?> rect = ValueNotifier<Rect?>(null);
 
+  bool _isPictureInPictureAvailable = false;
+
   /// {@macro platform_video_controller}
   VideoController(
     Player player, {
@@ -102,18 +104,60 @@ class VideoController {
           controller.id.removeListener(fn0);
           controller.rect.removeListener(fn1);
         });
+
+        _isPictureInPictureAvailable =
+            await controller.isPictureInPictureAvailable();
       } else {
         platform.completeError(
           UnimplementedError(
             '[VideoController] is unavailable for this platform.',
           ),
         );
+
+        _isPictureInPictureAvailable = false;
       }
 
       if (!(player.platform?.videoControllerCompleter.isCompleted ?? true)) {
         player.platform?.videoControllerCompleter.complete();
       }
     }();
+  }
+
+  /// Checks whether Picture in Picture is available on current platform.
+  bool isPictureInPictureAvailable() {
+    return _isPictureInPictureAvailable;
+  }
+
+  /// Enable Picture in Picture.
+  /// Returns true if this is supported on current platofrm.
+  Future<bool> enablePictureInPicture() async {
+    final instance = await platform.future;
+    return instance.enablePictureInPicture();
+  }
+
+  /// Disable Picture in Picture.
+  Future<void> disablePictureInPicture() async {
+    final instance = await platform.future;
+    return instance.disablePictureInPicture();
+  }
+
+  /// Enable automatically entering Picture in Picture when app goes into background.
+  /// Returns true if this is supported on current platofrm.
+  Future<bool> enableAutoPictureInPicture() async {
+    final instance = await platform.future;
+    return instance.enableAutoPictureInPicture();
+  }
+
+  /// Disables automatically entering Picture in Picture when app goes into background.
+  Future<void> disableAutoPictureInPicture() async {
+    final instance = await platform.future;
+    return instance.disableAutoPictureInPicture();
+  }
+
+  /// Enters Picture in Picture view for current video.
+  Future<bool> enterPictureInPicture() async {
+    final instance = await platform.future;
+    return instance.enterPictureInPicture();
   }
 
   /// Sets the required size of the video output.

--- a/media_kit_video/macos/Classes/plugin/common/VideoOutputPIP.swift
+++ b/media_kit_video/macos/Classes/plugin/common/VideoOutputPIP.swift
@@ -1,0 +1,1 @@
+../../../../common/darwin/Classes/plugin/VideoOutputPIP.swift


### PR DESCRIPTION
PIP with texture API is only available since iOS 15+ so this is a must.

To enable PIP app needs to have audio background mode enabled in Info.plist:
```
	<key>UIBackgroundModes</key>
	<array>
		<string>audio</string>
	</array>
```

and that's pretty much it. New APIs:

```
controller.isPictureInPictureAvailable() -> only returns true on iOS15+ platform
controller.enablePictureInPicture()
controller.disablePictureInPicture()
controller.enableAutoPictureInPicture() -> when app goes into background, currently playing video will automatically go into PiP
controller.disableAutoPictureInPicture()
controller.enterPictureInPicture() -> requires PiP to be enabled first (or auto PIP)
```