### PR TITLE
fix: set/emit completed=false upon seek (#221)

### DIFF
--- a/media_kit/lib/src/player/libmpv/player/real.dart
+++ b/media_kit/lib/src/player/libmpv/player/real.dart
@@ -569,6 +569,13 @@ class libmpvPlayer extends PlatformPlayer {
         args.cast(),
       );
       calloc.free(args);
+
+      // It is self explanatory that PlayerState.completed & PlayerStreams.completed must enter the false state if seek is called. Typically after EOF.
+      // https://github.com/alexmercerind/media_kit/issues/221
+      state = state.copyWith(completed: false);
+      if (!completedController.isClosed) {
+        completedController.add(false);
+      }
     }
 
     if (synchronized) {


### PR DESCRIPTION
- fix: set/emit completed=false upon seek (#221)
- test: player-seek-after-completed & more strict checks