### PR TITLE
fix: default volume 1 to 100 in player state

### DIFF
--- a/media_kit/lib/src/models/player_state.dart
+++ b/media_kit/lib/src/models/player_state.dart
@@ -82,7 +82,7 @@ class PlayerState {
     this.position = Duration.zero,
     this.duration = Duration.zero,
     this.buffer = Duration.zero,
-    this.volume = 1.0,
+    this.volume = 100.0,
     this.rate = 1.0,
     this.pitch = 1.0,
     this.buffering = false,


### PR DESCRIPTION
Changing the default volume in player state from 1 to 100, 