### PR TITLE
fix(wakelock): Migrate to wakelock_plus

### DIFF
--- a/media_kit_test/android/app/build.gradle
+++ b/media_kit_test/android/app/build.gradle
@@ -44,7 +44,7 @@ android {
 
     defaultConfig {
         applicationId "com.alexmercerind.media_kit_test"
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 19
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/media_kit_video/lib/src/video/video_texture.dart
+++ b/media_kit_video/lib/src/video/video_texture.dart
@@ -4,7 +4,7 @@
 /// All rights reserved.
 /// Use of this source code is governed by MIT license that can be found in the LICENSE file.
 import 'package:flutter/widgets.dart';
-import 'package:wakelock/wakelock.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 import 'package:media_kit_video/media_kit_video_controls/media_kit_video_controls.dart'
     as media_kit_video_controls;
 
@@ -129,14 +129,14 @@ class VideoState extends State<Video> {
   void initState() {
     super.initState();
     if (widget.wakelock) {
-      Wakelock.enable().catchError((_) {});
+      WakelockPlus.enable().catchError((_) {});
     }
   }
 
   @override
   void dispose() {
     if (widget.wakelock) {
-      Wakelock.disable().catchError((_) {});
+      WakelockPlus.disable().catchError((_) {});
     }
     super.dispose();
   }

--- a/media_kit_video/lib/src/video/video_web.dart
+++ b/media_kit_video/lib/src/video/video_web.dart
@@ -4,7 +4,7 @@
 /// All rights reserved.
 /// Use of this source code is governed by MIT license that can be found in the LICENSE file.
 import 'package:flutter/widgets.dart';
-import 'package:wakelock/wakelock.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 import 'package:media_kit_video/media_kit_video_controls/media_kit_video_controls.dart'
     as media_kit_video_controls;
 
@@ -132,14 +132,14 @@ class VideoState extends State<Video> {
   void initState() {
     super.initState();
     if (widget.wakelock) {
-      Wakelock.enable().catchError((_) {});
+      WakelockPlus.enable().catchError((_) {});
     }
   }
 
   @override
   void dispose() {
     if (widget.wakelock) {
-      Wakelock.disable().catchError((_) {});
+      WakelockPlus.disable().catchError((_) {});
     }
     super.dispose();
   }

--- a/media_kit_video/pubspec.yaml
+++ b/media_kit_video/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   flutter:
     sdk: flutter
   ffi: ^2.0.1
-  wakelock: ^0.6.2
+  wakelock_plus: ^1.1.0
   synchronized: ^3.1.0
   screen_brightness: ^0.2.2
   volume_controller: ^2.0.7


### PR DESCRIPTION
## Description

This PR migrates the project from the outdated `wakelock` package to `wakelock_plus`. The `wakelock` package currently has an outdated win32 version and hasn’t been updated in 12 months, while `wakelock_plus` is managed by the Flutter community and provides the latest updates and improvements.

## Checklist

- [x] Updated package dependencies in `pubspec.yaml` to use `wakelock_plus` instead of `wakelock`.
- [x] Updated import statements throughout the project to import `wakelock_plus` instead of `wakelock`.
- [x] Updated code usages of `wakelock` API to use the corresponding `wakelock_plus` API.
- [x] Removed any unnecessary code related to `wakelock` package.

## Changes Made

- Updated package dependencies in `pubspec.yaml` to use `wakelock_plus` instead of `wakelock`.
- Updated import statements throughout the project to import `wakelock_plus` instead of `wakelock`.
- Updated code usages of `wakelock` API to use the corresponding `wakelock_plus` API.
- Removed any unnecessary code related to `wakelock` package.

## Testing

- Ran existing tests to ensure that the functionality is preserved after the migration.
- Tested on both Android and iOS devices/emulators to ensure proper behavior with `wakelock_plus`.
