### PR TITLE
perf: vid=no until `VideoController` attach; build(windows): bump native libraries

### DIFF
--- a/libs/windows/media_kit_libs_windows_audio/CHANGELOG.md
+++ b/libs/windows/media_kit_libs_windows_audio/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.4
 
-- [mpv-player/mpv@`68b3239`](https://github.com/mpv-player/mpv/commit/68b3239b523cd75ba0a12f680ac7bc77e5647d40)
+- [mpv-player/mpv@`140ec21`](https://github.com/mpv-player/mpv/commit/140ec21c89d671d392877a7f3b91d67e7d7b9239)
 - perf: reduce bundle size
 
 ## 1.0.3

--- a/libs/windows/media_kit_libs_windows_audio/README.md
+++ b/libs/windows/media_kit_libs_windows_audio/README.md
@@ -4,7 +4,7 @@
 
 Windows package providing audio (only) native libraries for [`package:media_kit`](https://github.com/alexmercerind/media_kit).
 
-Visit [alexmercerind/mpv-win32-cmake@`disable-gl`](https://github.com/alexmercerind/mpv-win32-cmake/tree/disable-gl) for descriptive details.
+Visit [media-kit/libmpv-win32-audio-cmake@`master`](https://github.com/media-kit/libmpv-win32-audio-cmake) & [media-kit/libmpv-win32-audio-build@`master`](https://github.com/media-kit/libmpv-win32-audio-build) for descriptive details.
 
 Thanks to [Mitchel Stewart](https://github.com/Quackdoc) for providing patches to generate minimal libmpv & FFmpeg audio specific builds.
 

--- a/libs/windows/media_kit_libs_windows_video/CHANGELOG.md
+++ b/libs/windows/media_kit_libs_windows_video/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.0.4
+
+- [mpv-player/mpv@`140ec21`](https://github.com/mpv-player/mpv/commit/140ec21c89d671d392877a7f3b91d67e7d7b9239)
+- [ANGLE 2.1.18844 git hash: 2693b03eba82](https://github.com/google/angle)
+- MSVCRT
+- UCRT
+
 ## 1.0.2
 
 - [mpv-player/mpv@`7ae7fc0`](https://github.com/mpv-player/mpv/commit/7ae7fc01122c4fdfdb51600463872a6f8e78b975)

--- a/libs/windows/media_kit_libs_windows_video/README.md
+++ b/libs/windows/media_kit_libs_windows_video/README.md
@@ -4,7 +4,7 @@
 
 Windows package providing video (& audio) native libraries for [`package:media_kit`](https://github.com/alexmercerind/media_kit).
 
-Visit [alexmercerind/mpv-win32-cmake@`master`](https://github.com/alexmercerind/mpv-win32-cmake/tree/master) for descriptive details.
+Visit [media-kit/libmpv-win32-video-cmake@`master`](https://github.com/media-kit/libmpv-win32-video-cmake) & [media-kit/libmpv-win32-video-build@`master`](https://github.com/media-kit/libmpv-win32-video-build) for descriptive details.
 
 ## Support
 

--- a/libs/windows/media_kit_libs_windows_video/example/README.md
+++ b/libs/windows/media_kit_libs_windows_video/example/README.md
@@ -4,7 +4,7 @@ Add in your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  media_kit_libs_windows_audio: ^1.0.2
+  media_kit_libs_windows_audio: ^1.0.4
 ```
 
 This will automatically bundle required shared libraries for video (& audio) playback on Windows.

--- a/libs/windows/media_kit_libs_windows_video/pubspec.yaml
+++ b/libs/windows/media_kit_libs_windows_video/pubspec.yaml
@@ -1,6 +1,6 @@
 name: media_kit_libs_windows_video
 description: Windows package providing video (& audio) native libraries for package:media_kit.
-version: 1.0.2
+version: 1.0.4
 homepage: https://github.com/alexmercerind/media_kit.git
 repository: https://github.com/alexmercerind/media_kit.git
 funding:

--- a/libs/windows/media_kit_libs_windows_video/windows/CMakeLists.txt
+++ b/libs/windows/media_kit_libs_windows_video/windows/CMakeLists.txt
@@ -48,11 +48,11 @@ target_link_libraries(
 # ------------------------------------------------------------------------------
 
 # libmpv archive containing the pre-built shared libraries & headers.
-set(LIBMPV "mpv-dev-x86_64-20230408-git-7ae7fc0.7z")
+set(LIBMPV "mpv-dev-x86_64-20230719-git-140ec21.7z")
 
 # Download URL & MD5 hash of the libmpv archive.
-set(LIBMPV_URL "https://github.com/media-kit/libmpv-win32-video-build/releases/download/2023-04-08/${LIBMPV}")
-set(LIBMPV_MD5 "3d6e3686b5d543dfed6a775b8bff6b14")
+set(LIBMPV_URL "https://github.com/media-kit/libmpv-win32-video-build/releases/download/2023-07-19/${LIBMPV}")
+set(LIBMPV_MD5 "86204f54ed914321a95977e3f68c181a")
 
 # Download location of the libmpv archive.
 set(LIBMPV_ARCHIVE "${CMAKE_BINARY_DIR}/${LIBMPV}")
@@ -93,7 +93,7 @@ endif()
 set(ANGLE "ANGLE.7z")
 
 # Download URL & MD5 hash of the ANGLE archive.
-set(ANGLE_URL "https://github.com/alexmercerind/flutter-windows-OpenGLES/releases/download/v1.0.0/ANGLE.7z")
+set(ANGLE_URL "https://github.com/alexmercerind/flutter-windows-ANGLE-OpenGL-ES/releases/download/v1.0.0/ANGLE.7z")
 set(ANGLE_MD5 "e5be38d0e1c5cbe5f70e53701ea8b6c9")
 
 # Download location of the ANGLE archive.

--- a/media_kit/lib/src/player/platform_player.dart
+++ b/media_kit/lib/src/player/platform_player.dart
@@ -68,7 +68,7 @@ abstract class PlatformPlayer {
   );
 
   @mustCallSuper
-  FutureOr<void> dispose() async {
+  Future<void> dispose() async {
     await Future.wait(
       [
         playlistController.close(),
@@ -105,7 +105,7 @@ abstract class PlatformPlayer {
     }
   }
 
-  FutureOr<void> open(
+  Future<void> open(
     Playable playable, {
     bool play = true,
   }) {
@@ -122,121 +122,121 @@ abstract class PlatformPlayer {
     );
   }
 
-  FutureOr<void> play() {
+  Future<void> play() {
     throw UnimplementedError(
       '[PlatformPlayer.play] is not implemented',
     );
   }
 
-  FutureOr<void> pause() {
+  Future<void> pause() {
     throw UnimplementedError(
       '[PlatformPlayer.pause] is not implemented',
     );
   }
 
-  FutureOr<void> playOrPause() {
+  Future<void> playOrPause() {
     throw UnimplementedError(
       '[PlatformPlayer.playOrPause] is not implemented',
     );
   }
 
-  FutureOr<void> add(Media media) {
+  Future<void> add(Media media) {
     throw UnimplementedError(
       '[PlatformPlayer.add] is not implemented',
     );
   }
 
-  FutureOr<void> remove(int index) {
+  Future<void> remove(int index) {
     throw UnimplementedError(
       '[PlatformPlayer.remove] is not implemented',
     );
   }
 
-  FutureOr<void> next() {
+  Future<void> next() {
     throw UnimplementedError(
       '[PlatformPlayer.next] is not implemented',
     );
   }
 
-  FutureOr<void> previous() {
+  Future<void> previous() {
     throw UnimplementedError(
       '[PlatformPlayer.previous] is not implemented',
     );
   }
 
-  FutureOr<void> jump(int index) {
+  Future<void> jump(int index) {
     throw UnimplementedError(
       '[PlatformPlayer.jump] is not implemented',
     );
   }
 
-  FutureOr<void> move(int from, int to) {
+  Future<void> move(int from, int to) {
     throw UnimplementedError(
       '[PlatformPlayer.move] is not implemented',
     );
   }
 
-  FutureOr<void> seek(Duration duration) {
+  Future<void> seek(Duration duration) {
     throw UnimplementedError(
       '[PlatformPlayer.seek] is not implemented',
     );
   }
 
-  FutureOr<void> setPlaylistMode(PlaylistMode playlistMode) {
+  Future<void> setPlaylistMode(PlaylistMode playlistMode) {
     throw UnimplementedError(
       '[PlatformPlayer.setPlaylistMode] is not implemented',
     );
   }
 
-  FutureOr<void> setVolume(double volume) {
+  Future<void> setVolume(double volume) {
     throw UnimplementedError(
       '[PlatformPlayer.volume] is not implemented',
     );
   }
 
-  FutureOr<void> setRate(double rate) {
+  Future<void> setRate(double rate) {
     throw UnimplementedError(
       '[PlatformPlayer.rate] is not implemented',
     );
   }
 
-  FutureOr<void> setPitch(double pitch) {
+  Future<void> setPitch(double pitch) {
     throw UnimplementedError(
       '[PlatformPlayer.pitch] is not implemented',
     );
   }
 
-  FutureOr<void> setShuffle(bool shuffle) {
+  Future<void> setShuffle(bool shuffle) {
     throw UnimplementedError(
       '[PlatformPlayer.shuffle] is not implemented',
     );
   }
 
-  FutureOr<void> setAudioDevice(AudioDevice audioDevice) {
+  Future<void> setAudioDevice(AudioDevice audioDevice) {
     throw UnimplementedError(
       '[PlatformPlayer.setAudioDevice] is not implemented',
     );
   }
 
-  FutureOr<void> setVideoTrack(VideoTrack track) {
+  Future<void> setVideoTrack(VideoTrack track) {
     throw UnimplementedError(
       '[PlatformPlayer.setVideoTrack] is not implemented',
     );
   }
 
-  FutureOr<void> setAudioTrack(AudioTrack track) {
+  Future<void> setAudioTrack(AudioTrack track) {
     throw UnimplementedError(
       '[PlatformPlayer.setAudioTrack] is not implemented',
     );
   }
 
-  FutureOr<void> setSubtitleTrack(SubtitleTrack track) {
+  Future<void> setSubtitleTrack(SubtitleTrack track) {
     throw UnimplementedError(
       '[PlatformPlayer.setSubtitleTrack] is not implemented',
     );
   }
 
-  FutureOr<Uint8List?> screenshot({String format = 'image/jpeg'}) async {
+  Future<Uint8List?> screenshot({String format = 'image/jpeg'}) async {
     throw UnimplementedError(
       '[PlatformPlayer.screenshot] is not implemented',
     );
@@ -340,8 +340,15 @@ abstract class PlatformPlayer {
   final StreamController<List<String>> subtitleController =
       StreamController<List<String>>.broadcast();
 
-  /// Publicly defined clean-up [Function]s which must be called before [dispose].
-  final List<Future<void> Function()> release = [];
+  // --------------------------------------------------
+
+  /// [Completer] to wait for initialization of this instance.
+  final Completer<void> completer = Completer<void>();
+
+  /// [Future<void>] to wait for initialization of this instance.
+  Future<void> get waitForPlayerInitialization => completer.future;
+
+  // --------------------------------------------------
 
   /// [bool] for signaling [VideoController] (from `package:media_kit_video`) initialization.
   bool isVideoControllerAttached = false;
@@ -356,6 +363,11 @@ abstract class PlatformPlayer {
     }
     return Future.value(null);
   }
+
+  // --------------------------------------------------
+
+  /// Publicly defined clean-up [Function]s which must be called before [dispose].
+  final List<Future<void> Function()> release = [];
 }
 
 /// {@template player_configuration}

--- a/media_kit/lib/src/player/web/player/real.dart
+++ b/media_kit/lib/src/player/web/player/real.dart
@@ -43,7 +43,7 @@ class WebPlayer extends PlatformPlayer {
   WebPlayer({required super.configuration})
       : id = js.context[kInstanceCount] ?? 0,
         element = html.VideoElement() {
-    lock.synchronized(() async {
+    lock.synchronized(() {
       element
         // Do not add autoplay=false attribute: https://stackoverflow.com/a/19664804/12825435
         /* ..autoplay = false */
@@ -302,7 +302,10 @@ class WebPlayer extends PlatformPlayer {
           }
         });
       });
-      configuration.ready?.call();
+      completer.complete();
+      try {
+        configuration.ready?.call();
+      } catch (_) {}
       // --------------------------------------------------
     });
   }
@@ -1448,10 +1451,6 @@ class WebPlayer extends PlatformPlayer {
 
   /// Whether the [Player] has been disposed.
   bool disposed = false;
-
-  /// [Future<void>] to wait for initialization of this instance.
-  Future<void> get waitForPlayerInitialization =>
-      Future.value() /* Not required. */;
 
   /// Synchronization & mutual exclusion between methods of this class.
   final Lock lock = Lock();

--- a/media_kit/test/src/player/player_test.dart
+++ b/media_kit/test/src/player/player_test.dart
@@ -60,6 +60,19 @@ void main() {
     skip: !UniversalPlatform.isWeb,
   );
   test(
+    'player-wait-for-player-initialization',
+    () async {
+      final player = Player();
+      final future = player.platform?.waitForPlayerInitialization;
+      expect(future, isNotNull);
+      expect(future, completes);
+
+      await Future.delayed(const Duration(seconds: 10));
+
+      await player.dispose();
+    },
+  );
+  test(
     'player-handle',
     () {
       final player = Player();

--- a/media_kit_video/lib/src/video_controller/android_video_controller/real.dart
+++ b/media_kit_video/lib/src/video_controller/android_video_controller/real.dart
@@ -26,6 +26,8 @@ import 'package:media_kit/generated/libmpv/bindings.dart';
 import 'package:media_kit_video/src/video_controller/video_controller.dart';
 import 'package:media_kit_video/src/video_controller/platform_video_controller.dart';
 
+import 'package:media_kit_video/src/video_controller/utils/query_decoders.dart';
+
 /// {@template android_video_controller}
 ///
 /// AndroidVideoController
@@ -199,14 +201,26 @@ class AndroidVideoController extends PlatformVideoController {
     final int wid = data['wid'];
     debugPrint(data.toString());
 
+    // In case no video-decoders are found, this means media_kit_libs_***_audio is being used.
+    // Thus, --vid=no is required to prevent libmpv from trying to decode video (otherwise bad things may happen).
+    //
+    // Search for common H264 decoder to check if video support is available.
+    final decoders = await queryDecoders(handle);
+    if (!decoders.contains('h264')) {
+      throw UnsupportedError(
+        '[VideoController] is not available.'
+        ' '
+        'Please use media_kit_libs_***_video instead of media_kit_libs_***_audio.',
+      );
+    }
+
     // ----------------------------------------------
     NativeLibrary.ensureInitialized();
     final mpv = MPV(DynamicLibrary.open(NativeLibrary.path));
-
     final values = configuration.vo == null || configuration.hwdec == null
         ? enableHardwareAcceleration
             ? {
-                // H/W decoding & rendering with --vo=gpu + --hwdec=mediacodec-copy.
+                // H/W decoding & rendering with --vo=gpu + --hwdec=mediacodec.
                 'vo': 'gpu',
                 'hwdec': 'mediacodec',
                 'vid': 'auto',

--- a/media_kit_video/lib/src/video_controller/native_video_controller/real.dart
+++ b/media_kit_video/lib/src/video_controller/native_video_controller/real.dart
@@ -20,6 +20,8 @@ import 'package:media_kit/generated/libmpv/bindings.dart';
 import 'package:media_kit_video/src/video_controller/video_controller.dart';
 import 'package:media_kit_video/src/video_controller/platform_video_controller.dart';
 
+import 'package:media_kit_video/src/video_controller/utils/query_decoders.dart';
+
 /// {@template native_video_controller}
 ///
 /// NativeVideoController
@@ -70,6 +72,19 @@ class NativeVideoController extends PlatformVideoController {
       player,
       configuration,
     );
+
+    // In case no video-decoders are found, this means media_kit_libs_***_audio is being used.
+    // Thus, --vid=no is required to prevent libmpv from trying to decode video (otherwise bad things may happen).
+    //
+    // Search for common H264 decoder to check if video support is available.
+    final decoders = await queryDecoders(handle);
+    if (!decoders.contains('h264')) {
+      throw UnsupportedError(
+        '[VideoController] is not available.'
+        ' '
+        'Please use media_kit_libs_***_video instead of media_kit_libs_***_audio.',
+      );
+    }
 
     // ----------------------------------------------
     NativeLibrary.ensureInitialized();

--- a/media_kit_video/lib/src/video_controller/utils/query_decoders.dart
+++ b/media_kit_video/lib/src/video_controller/utils/query_decoders.dart
@@ -1,0 +1,68 @@
+/// This file is a part of media_kit (https://github.com/alexmercerind/media_kit).
+///
+/// Copyright © 2021 & onwards, Hitesh Kumar Saini <saini123hitesh@gmail.com>.
+/// All rights reserved.
+/// Use of this source code is governed by MIT license that can be found in the LICENSE file.
+import 'dart:ffi';
+import 'dart:collection';
+import 'package:synchronized/synchronized.dart';
+// ignore_for_file: unused_import, implementation_imports
+import 'package:media_kit/ffi/ffi.dart';
+import 'package:media_kit/src/player/native/core/native_library.dart';
+
+import 'package:media_kit/generated/libmpv/bindings.dart';
+
+/// Returns the list of available decoders available in libavcodec.
+/// Takes raw address to `mpv_handle*` as [handle].
+///
+/// https://mpv.io/manual/stable/#command-interface-decoder-list
+Future<HashSet<String>> queryDecoders(int handle) {
+  return _lock.synchronized(() {
+    if (_decoders.isNotEmpty) {
+      return _decoders;
+    }
+
+    NativeLibrary.ensureInitialized();
+    final mpv = MPV(DynamicLibrary.open(NativeLibrary.path));
+
+    if (_decoders.isEmpty) {
+      final name = 'decoder-list'.toNativeUtf8();
+      final data = calloc<mpv_node>();
+      mpv.mpv_get_property(
+        Pointer.fromAddress(handle),
+        name.cast(),
+        mpv_format.MPV_FORMAT_NODE,
+        data.cast(),
+      );
+      if (data.ref.format == mpv_format.MPV_FORMAT_NODE_ARRAY) {
+        for (int i = 0; i < data.ref.u.list.ref.num; i++) {
+          final decoder = data.ref.u.list.ref.values[i];
+          if (decoder.format == mpv_format.MPV_FORMAT_NODE_MAP) {
+            String? name;
+            for (int j = 0; j < decoder.u.list.ref.num; j++) {
+              final k = decoder.u.list.ref.keys[j].cast<Utf8>().toDartString();
+              final v = decoder.u.list.ref.values[j];
+              if (k == 'codec' && v.format == mpv_format.MPV_FORMAT_STRING) {
+                name ??= v.u.string.cast<Utf8>().toDartString();
+              }
+              if (k == 'driver' && v.format == mpv_format.MPV_FORMAT_STRING) {
+                name ??= v.u.string.cast<Utf8>().toDartString();
+              }
+            }
+            if (name != null) {
+              _decoders.add(name);
+            }
+          }
+        }
+      }
+      mpv.mpv_free_node_contents(data);
+      calloc.free(name);
+      calloc.free(data);
+    }
+
+    return _decoders;
+  });
+}
+
+final Lock _lock = Lock();
+final HashSet<String> _decoders = HashSet<String>();

--- a/media_kit_video/lib/src/video_controller/video_controller.dart
+++ b/media_kit_video/lib/src/video_controller/video_controller.dart
@@ -98,31 +98,33 @@ class VideoController {
           platform.complete(result);
           notifier.value = result;
         }
+
+        if (platform.isCompleted) {
+          // Populate [id] & [rect] [ValueNotifier]s with the values from [platform] implementation of [PlatformVideoController].
+          final controller = await platform.future;
+          // Add listeners.
+          void fn0() => id.value = controller.id.value;
+          void fn1() => rect.value = controller.rect.value;
+          fn0();
+          fn1();
+          controller.id.addListener(fn0);
+          controller.rect.addListener(fn1);
+          // Remove listeners upon [Player.dispose].
+          player.platform?.release.add(() async {
+            controller.id.removeListener(fn0);
+            controller.rect.removeListener(fn1);
+          });
+        } else {
+          platform.completeError(
+            UnimplementedError(
+              '[VideoController] is unavailable for this platform.',
+            ),
+          );
+        }
       } catch (exception, stacktrace) {
+        platform.completeError(exception);
         debugPrint(exception.toString());
         debugPrint(stacktrace.toString());
-      }
-      if (platform.isCompleted) {
-        // Populate [id] & [rect] [ValueNotifier]s with the values from [platform] implementation of [PlatformVideoController].
-        final controller = await platform.future;
-        // Add listeners.
-        void fn0() => id.value = controller.id.value;
-        void fn1() => rect.value = controller.rect.value;
-        fn0();
-        fn1();
-        controller.id.addListener(fn0);
-        controller.rect.addListener(fn1);
-        // Remove listeners upon [Player.dispose].
-        player.platform?.release.add(() async {
-          controller.id.removeListener(fn0);
-          controller.rect.removeListener(fn1);
-        });
-      } else {
-        platform.completeError(
-          UnimplementedError(
-            '[VideoController] is unavailable for this platform.',
-          ),
-        );
       }
 
       if (!(player.platform?.videoControllerCompleter.isCompleted ?? true)) {


### PR DESCRIPTION
Re-work things based on https://github.com/alexmercerind/media_kit/pull/287#issuecomment-1641110217.

Additionally handle a condition if media_kit_libs_***_audio are used with `VideoController` (audio still plays):

![](https://github.com/alexmercerind/media_kit/assets/28951144/298da5f1-3e89-4f39-b147-230b32e712ad)
