### PR TITLE
Do not add onTapUp callback if toggleFullscreenOnDoublePress is disabled

### DIFF
--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
@@ -581,14 +581,14 @@ class _MaterialDesktopVideoControlsState
                     }
                   : null,
               child: GestureDetector(
-                onTapUp: (e) {
-                  if (_theme(context).toggleFullscreenOnDoublePress) {
-                    final now = DateTime.now();
-                    final difference = now.difference(last);
-                    last = now;
-                    if (difference < const Duration(milliseconds: 400)) {
-                      toggleFullscreen(context);
-                    }
+                onTapUp: !_theme(context).toggleFullscreenOnDoublePress
+                    ? null
+                    : (e) {
+                  final now = DateTime.now();
+                  final difference = now.difference(last);
+                  last = now;
+                  if (difference < const Duration(milliseconds: 400)) {
+                    toggleFullscreen(context);
                   }
                 },
                 onPanUpdate: _theme(context).modifyVolumeOnScroll


### PR DESCRIPTION
This allows you to wrap your Video widget with additional GestureDetector to add onTap callbacks. Right now if you wrap this widget with GestureDetector then you won't be able to execute any onTap callbacks. Of course this could be done with Listener widget, but then it will cover whole player, even play/resume buttons, etc., what's not good