### PR TITLE
fix: remove TaskQueue/LockExt logic; fix: InitializerIsolate reduce Isolate.kill delay 

### DIFF
--- a/media_kit/lib/src/player/native/core/initializer_isolate.dart
+++ b/media_kit/lib/src/player/native/core/initializer_isolate.dart
@@ -107,7 +107,7 @@ abstract class InitializerIsolate {
       _ports.remove(handle.address);
       _isolates.remove(handle.address);
       // A voluntary delay. Although, [Isolate.kill] is not necessary since execution in the [Isolate] will stop automatically.
-      Future.delayed(const Duration(seconds: 10), () {
+      Future.delayed(const Duration(seconds: 2), () {
         isolate.kill(priority: Isolate.immediate);
       });
     }


### PR DESCRIPTION
- fix: remove `TaskQueue`/`LockExt` logic in `NativePlayer.dispose`
- fix: `InitializerIsolate` reduce `Isolate.kill` delay