### PR TITLE
fix: remove deprecated onSurfaceCreated/onSurfaceDestroyed

### DIFF
--- a/media_kit_video/android/src/main/java/com/alexmercerind/media_kit_video/VideoOutput.java
+++ b/media_kit_video/android/src/main/java/com/alexmercerind/media_kit_video/VideoOutput.java
@@ -71,7 +71,7 @@ public class VideoOutput implements TextureRegistry.SurfaceProducer.Callback {
             } catch (Throwable e) {
                 Log.e(TAG, "dispose", e);
             }
-            onSurfaceDestroyed();
+            onSurfaceCleanup();
         }
     }
 
@@ -86,7 +86,7 @@ public class VideoOutput implements TextureRegistry.SurfaceProducer.Callback {
                     return;
                 }
                 surfaceProducer.setSize(width, height);
-                onSurfaceCreated();
+                onSurfaceAvailable();
             } catch (Throwable e) {
                 Log.e(TAG, "setSurfaceSize", e);
             }
@@ -94,9 +94,9 @@ public class VideoOutput implements TextureRegistry.SurfaceProducer.Callback {
     }
 
     @Override
-    public void onSurfaceCreated() {
+    public void onSurfaceAvailable() {
         synchronized (lock) {
-            Log.i(TAG, "onSurfaceCreated");
+            Log.i(TAG, "onSurfaceAvailable");
             id = surfaceProducer.id();
             wid = newGlobalObjectRef(surfaceProducer.getSurface());
             textureUpdateCallback.onTextureUpdate(id, wid, surfaceProducer.getWidth(), surfaceProducer.getHeight());
@@ -104,9 +104,9 @@ public class VideoOutput implements TextureRegistry.SurfaceProducer.Callback {
     }
 
     @Override
-    public void onSurfaceDestroyed() {
+    public void onSurfaceCleanup() {
         synchronized (lock) {
-            Log.i(TAG, "onSurfaceDestroyed");
+            Log.i(TAG, "onSurfaceCleanup");
             textureUpdateCallback.onTextureUpdate(id, 0, surfaceProducer.getWidth(), surfaceProducer.getHeight());
             if (wid != 0) {
                 final long widReference = wid;


### PR DESCRIPTION
onSurfaceCreated() and onSurfaceDestroyed() in TextureRegistry have been deprecated in Flutter 3.27 and 3.28 respectively, in favor of onSurfaceAvailable() and onSurfaceCleanup().

References:
- https://github.com/flutter/flutter/blob/e3b301f23d35cacf5e054cf0e23ac49ea7f0086d/engine/src/flutter/shell/platform/android/io/flutter/view/TextureRegistry.java#L156
- https://github.com/flutter/flutter/issues/161256