### PR TITLE
Fix crash on Wayland/EGL (Ubuntu Frame) during video dispose in media_kit_video

### DIFF
--- a/media_kit_video/linux/video_output.cc
+++ b/media_kit_video/linux/video_output.cc
@@ -38,6 +38,12 @@ G_DEFINE_TYPE(VideoOutput, video_output, G_TYPE_OBJECT)
 static void video_output_dispose(GObject* object) {
   VideoOutput* self = VIDEO_OUTPUT(object);
   self->destroyed = TRUE;
+
+  // Make sure that no more callbacks are invoked from mpv.
+  if (self->render_context) {
+    mpv_render_context_set_update_callback(self->render_context, NULL, NULL);
+  }
+
   // H/W
   if (self->texture_gl) {
     fl_texture_registrar_unregister_texture(self->texture_registrar,


### PR DESCRIPTION
This pull request addresses Issue [#1287] (crash on Wayland/EGL when disposing a video).

When disposing a video under Wayland / EGL environments (for example Ubuntu Frame), the application could crash with the following error:
```
epoxy_get_proc_address: Assertion `0 && "Couldn't find current GLX or EGL context.\n"' failed.
Aborted
```

#### Root cause

During teardown, TextureGL and VideoOutput performed OpenGL calls (glDeleteTextures, glDeleteFramebuffers, etc.) without a valid current GL context. Under Wayland/EGL — particularly in headless kiosk setups like Ubuntu Frame — the GDK GL context may already be destroyed or invalid by the time dispose executes. Invoking GL functions at that point triggers a libepoxy assertion and aborts the process.

#### Fix summary

This patch adds safety guards to the dispose path:
- TextureGL
    - Deletes GL textures and framebuffers only when a valid and current GdkGLContext is available.
    - If no valid context exists, the handles are simply reset and no GL calls are made.
- VideoOutput
    - Detaches the mpv_render_context update callback before freeing the render context.
    - Prevents late render callbacks after the object has been destroyed.

These changes ensure that no GL functions are invoked without a valid context during teardown.

#### Results
- Verified on Ubuntu Core 24 running Ubuntu Frame (Wayland/EGL, Mesa DRI).
- The crash (epoxy_get_proc_address assertion) no longer occurs when closing or disposing videos.