### PR TITLE
fix(linux): make gl context current before creating mpv render

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "xlocale": "cpp"
-    }
-}


### PR DESCRIPTION
fixes #1279

We did not explicitly activate the OpenGL context after creating it, which leads to the OpenGL context being probabilistically unusable on some graphics hardware.