### PR TITLE
fix(linux): fix linux hardware render flick

### DIFF
--- a/media_kit_video/linux/texture_gl.cc
+++ b/media_kit_video/linux/texture_gl.cc
@@ -31,10 +31,9 @@ static void texture_gl_init(TextureGL* self) {
 
 static void texture_gl_dispose(GObject* object) {
   TextureGL* self = TEXTURE_GL(object);
-
   // Only delete OpenGL resources if there is a valid OpenGL context.
   gboolean deleted = FALSE;
-  if(self->video_output != NULL){
+  if (self->video_output != NULL) {
     GdkGLContext* ctx = video_output_get_gdk_gl_context(self->video_output);
     if (ctx != NULL) {
       gdk_gl_context_make_current(ctx);
@@ -51,8 +50,7 @@ static void texture_gl_dispose(GObject* object) {
       }
     }
   }
-
-  if(!deleted){
+  if (!deleted) {
     self->name = 0;
     self->fbo = 0;
   }
@@ -81,6 +79,17 @@ gboolean texture_gl_populate_texture(FlTextureGL* texture,
                                      GError** error) {
   TextureGL* self = TEXTURE_GL(texture);
   VideoOutput* video_output = self->video_output;
+  
+  // Save the current GL context state of Flutter
+  GdkGLContext* ctx = video_output_get_gdk_gl_context(video_output);
+  GdkGLContext* current_ctx = gdk_gl_context_get_current();
+  
+  // Only switch if our context is not the current context
+  gboolean need_context_switch = (ctx != NULL && current_ctx != ctx);
+  if (need_context_switch) {
+    gdk_gl_context_make_current(ctx);
+  }
+  
   gint32 required_width = (guint32)video_output_get_width(video_output);
   gint32 required_height = (guint32)video_output_get_height(video_output);
   if (required_width > 0 && required_height > 0) {
@@ -126,6 +135,10 @@ gboolean texture_gl_populate_texture(FlTextureGL* texture,
     };
     mpv_render_context_render(render_context, params);
   }
+  
+  // Unbind the FBO before returning to Flutter to avoid interfering with Flutter's rendering
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+  
   *target = GL_TEXTURE_2D;
   *name = self->name;
   *width = self->current_width;
@@ -138,9 +151,19 @@ gboolean texture_gl_populate_texture(FlTextureGL* texture,
     glBindFramebuffer(GL_FRAMEBUFFER, self->fbo);
     glGenTextures(1, &self->name);
     glBindTexture(GL_TEXTURE_2D, self->name);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
     *name = self->name;
     *width = 1;
     *height = 1;
   }
+  
+  // If we switched to our context, restore the previous context
+  if (need_context_switch && current_ctx != NULL) {
+    gdk_gl_context_make_current(current_ctx);
+  } else if (need_context_switch) {
+    // If there was no previous context, clear the current context
+    gdk_gl_context_clear_current();
+  }
+  
   return TRUE;
 }


### PR DESCRIPTION
This PR has two main parts:

1. `texture_gl.cc`: Saving the OpenGL state before rendering and restoring it afterward, which resolves the flickering issue.
2. `video_output.cc`: Addresses the frequent freeze on player exit introduced after the `texture_gl.cc` changes by ensuring mpv-related texture resources are disposed in the correct OpenGL context.