### PR TITLE
fix(android): seek to current playback position instead of start

### DIFF
--- a/media_kit_video/lib/src/video_controller/android_video_controller/real.dart
+++ b/media_kit_video/lib/src/video_controller/android_video_controller/real.dart
@@ -68,7 +68,10 @@ class AndroidVideoController extends PlatformVideoController {
           if (configuration.vo == 'mediacodec_embed') 'vid': vidValue,
         },
       );
-      await player.seek(Duration.zero);
+      // Instead of seeking to the start (Duration.zero), seek to the current playback position
+      // without jumping the user to the start of the media.
+      final currentPosition = player.state.position;
+      await player.seek(currentPosition);
     });
   }
 


### PR DESCRIPTION
Modified AndroidVideoController.widListener to seek to the current playback position instead of Duration.zero. This improves the UX by avoiding an unexpected rewind.