### PR TITLE
fix: fix flutter338 crash

### DIFF
--- a/media_kit/lib/src/player/native/core/initializer_native_callable.dart
+++ b/media_kit/lib/src/player/native/core/initializer_native_callable.dart
@@ -60,6 +60,11 @@ class InitializerNativeCallable {
   void dispose(Pointer<generated.mpv_handle> ctx) {
     _locks.remove(ctx.address);
     _eventCallbacks.remove(ctx.address);
+
+    // Clear the wakeup callback in libmpv before closing NativeCallable
+    // to prevent libmpv from invoking a deleted callback
+    mpv.mpv_set_wakeup_callback(ctx, nullptr, nullptr);
+    
     _wakeUpNativeCallables.remove(ctx.address)?.close();
   }
 


### PR DESCRIPTION
@alexmercerind 

The Flutter 3.38 stable was released about 12 hours ago, and this release has broken media-kit. The application now crashes whenever the dispose method is called. This occurs in release mode builds on all platforms. This PR fixes the issue. I strongly recommend a new media-kit version release after this PR is merged.

If you are interested in the crash stack, please refer to: https://github.com/Predidit/media-kit/actions/runs/19320211555