### PR TITLE
fix: fix flutter338 hot restart crash

### DIFF
--- a/media_kit/lib/src/player/native/core/initializer.dart
+++ b/media_kit/lib/src/player/native/core/initializer.dart
@@ -43,7 +43,7 @@ class Initializer {
     // registered `NativeCallable` trampolines. In debug mode, prefer the isolate
     // based implementation to avoid native -> Dart callbacks that can outlive
     // the isolate and crash with "Callback invoked after it has been deleted".
-    // See: https://github.com/media-kit/media-kit/issues/1348
+    // See: https://github.com/media-kit/media-kit/issues/1340
     if (kDebugMode) {
       return InitializerIsolate().create(callback, options: options);
     }

--- a/media_kit/test/src/player/native/core/initializer_test.dart
+++ b/media_kit/test/src/player/native/core/initializer_test.dart
@@ -13,44 +13,12 @@ import 'package:test/test.dart';
 import 'package:media_kit/ffi/ffi.dart';
 
 import 'package:media_kit/src/player/native/core/initializer.dart';
-import 'package:media_kit/src/player/native/core/initializer_isolate.dart';
-import 'package:media_kit/src/player/native/core/initializer_native_callable.dart';
 import 'package:media_kit/src/player/native/core/native_library.dart';
-import 'package:media_kit/src/player/native/core/execmem_restriction.dart';
-import 'package:media_kit/src/values.dart';
 
 import 'package:media_kit/generated/libmpv/bindings.dart';
 
 MPV? _mpv;
 MPV get mpv => _mpv!;
-
-Future<Pointer<mpv_handle>> _createProductionLikeHandle(
-  Future<void> Function(Pointer<mpv_event>) callback, {
-  Map<String, String> options = const {},
-}) {
-  // `Initializer` intentionally forces `InitializerIsolate` in debug mode to
-  // avoid hot-restart related issues with `NativeCallable` trampolines.
-  // These unit tests, however, want to exercise production behavior.
-  if (kDebugMode) {
-    if (!isExecmemRestricted) {
-      return InitializerNativeCallable(mpv).create(callback, options: options);
-    }
-    return InitializerIsolate().create(callback, options: options);
-  }
-  return Initializer(mpv).create(callback, options: options);
-}
-
-void _disposeProductionLikeHandle(Pointer<mpv_handle> handle) {
-  if (kDebugMode) {
-    if (!isExecmemRestricted) {
-      InitializerNativeCallable(mpv).dispose(handle);
-    } else {
-      InitializerIsolate().dispose(mpv, handle);
-    }
-    return;
-  }
-  Initializer(mpv).dispose(handle);
-}
 
 void main() {
   setUp(() {
@@ -61,7 +29,7 @@ void main() {
     'initializer-init',
     () {
       expect(
-        _createProductionLikeHandle((_) async {}),
+        Initializer(mpv).create((_) async {}),
         completes,
       );
     },
@@ -70,7 +38,7 @@ void main() {
     'initializer-create',
     () {
       expect(
-        _createProductionLikeHandle((_) async {}),
+        Initializer(mpv).create((_) async {}),
         completes,
       );
     },
@@ -78,9 +46,9 @@ void main() {
   test(
     'initializer-dispose',
     () async {
-      final handle = await _createProductionLikeHandle((_) async {});
+      final handle = await Initializer(mpv).create((_) async {});
       expect(
-        () => _disposeProductionLikeHandle(handle),
+        () => Initializer(mpv).dispose(handle),
         returnsNormally,
       );
     },
@@ -100,7 +68,7 @@ void main() {
         expect(true, isTrue);
       });
 
-      final handle = await _createProductionLikeHandle(
+      final handle = await Initializer(mpv).create(
         (event) async {
           if (event.ref.event_id == mpv_event_id.MPV_EVENT_PROPERTY_CHANGE) {
             final prop = event.ref.data.cast<mpv_event_property>();
@@ -146,13 +114,13 @@ void main() {
 
       await Future.delayed(const Duration(seconds: 5));
 
-      _disposeProductionLikeHandle(handle);
+      Initializer(mpv).dispose(handle);
     },
   );
   test(
     'initializer-options-with-callback',
     () async {
-      final handle = await _createProductionLikeHandle(
+      final handle = await Initializer(mpv).create(
         (_) async {},
         options: {
           'config': 'yes',
@@ -186,7 +154,7 @@ void main() {
 
       await Future.delayed(const Duration(seconds: 5));
 
-      _disposeProductionLikeHandle(handle);
+      Initializer(mpv).dispose(handle);
     },
   );
 }


### PR DESCRIPTION
Fixes https://github.com/media-kit/media-kit/issues/1340

The thread merging in the newer version of Flutter forces NativeCallable to be reset during hot restart. There is no clean way for us to receive the hot restart signal and handle it appropriately, making it difficult and error-prone to fix hot restart issues within the NativeCallable framework. I looked into how the flutter_asound plugin handles this, and it appears quite hacky.
This PR chooses to disable NativeCallable in debug mode and fall back to the old Dart isolate–based implementation, allowing us to resolve the issue with minimal cost.

ref: https://github.com/flutter/flutter/issues/178548