### PR TITLE
fix: avoid calling various APIs after disposal

### DIFF
--- a/media_kit_video/lib/src/video_controller/native_video_controller/real.dart
+++ b/media_kit_video/lib/src/video_controller/native_video_controller/real.dart
@@ -50,6 +50,8 @@ class NativeVideoController extends PlatformVideoController {
   /// [Lock] used to synchronize [onLoadHooks], [onUnloadHooks] & [subscription].
   final lock = Lock();
 
+  var _disposed = false;
+
   NativePlayer get platform => player.platform as NativePlayer;
 
   Future<void> setProperty(String key, String value) async {
@@ -74,7 +76,7 @@ class NativeVideoController extends PlatformVideoController {
         height = configuration.height {
     videoParamsSubscription = player.stream.videoParams.listen(
       (event) => lock.synchronized(() async {
-        if ([0, null].contains(event.dw) || [0, null].contains(event.dh)) {
+        if (_disposed || [0, null].contains(event.dw) || [0, null].contains(event.dh)) {
           return;
         }
 
@@ -91,7 +93,7 @@ class NativeVideoController extends PlatformVideoController {
           height = event.dw ?? 0;
         }
 
-        if (videoParamsWidth == width && videoParamsHeight == height) {
+        if (_disposed || videoParamsWidth == width && videoParamsHeight == height) {
           return;
         }
 
@@ -237,6 +239,7 @@ class NativeVideoController extends PlatformVideoController {
 
   /// Disposes the instance. Releases allocated resources back to the system.
   Future<void> _dispose() async {
+    _disposed = true;
     super.dispose();
     await videoParamsSubscription?.cancel();
     final handle = await player.handle;


### PR DESCRIPTION
Before this pull request, `PlatformVideoController` calls various APIs after they are no longer available as things have been disposed already.

This happens due to the synchronized `Lock`, causing callbacks which causes the `widListener` specifically to queue up operations, sometimes executing only after the actual listener has already been removed.

I encountered this bug multiple times for `AndroidVideoController`, in the wild and on dev PCs, so this actually happens. I also fixed it for `NativeVideoController` as it's probably just a matter of time until one encounters the same issue there.


```
I/flutter (24596):     Exception (AssertionError): Assertion failed: "[Player] has been disposed"
I/flutter (24596): 
I/flutter (24596):     #0      NativePlayer.setProperty (package:media_kit/src/player/native/player/real.dart:1229:7)
real.dart:1229
I/flutter (24596):     #1      AndroidVideoController.setProperty (package:media_kit_video/src/video_controller/android_video_controller/real.dart:39:20)
real.dart:39
I/flutter (24596):     #2      AndroidVideoController.widListener.<anonymous closure> (package:media_kit_video/src/video_controller/android_video_controller/real.dart:59:13)
real.dart:59
I/flutter (24596):     #3      BasicLock.synchronized (package:synchronized/src/basic_lock.dart:36:24)
basic_lock.dart:36
I/flutter (24596):     <asynchronous suspension>
```