### PR TITLE
feat(video-controls): add option to keep showing controls when video is paused

### DIFF
--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -1067,9 +1067,15 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                                         _timer?.cancel();
                                       },
                                       onSeekEnd: () {
+                                        if (!mounted) return;
+
                                         _timer = Timer(
                                           _theme(context).controlsHoverDuration,
                                           () {
+                                            if (!mounted) {
+                                              return;
+                                            }
+
                                             final isPlaying =
                                                 controller(context)
                                                     .player
@@ -1083,12 +1089,10 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                                               return;
                                             }
 
-                                            if (mounted) {
-                                              setState(() {
-                                                visible = false;
-                                              });
-                                              unshiftSubtitle();
-                                            }
+                                            setState(() {
+                                              visible = false;
+                                            });
+                                            unshiftSubtitle();
                                           },
                                         );
                                       },


### PR DESCRIPTION
- Introduced `controlsVisibleOnPause` property to `MaterialVideoControlsThemeData` to control visibility of video controls when the video is paused.