### PR TITLE
fix: video player conflicts with scroll widgets

### DIFF
--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -829,8 +829,11 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
 
   @override
   Widget build(BuildContext context) {
-    final verticalGesturesEnabled =
-        (_theme(context).brightnessGesture || (_theme(context).volumeGesture));
+    final verticalGesturesEnabled = ((_theme(context).brightnessGesture &&
+            _theme(context).onBrightnessChanged != null) ||
+        (_theme(context).volumeGesture &&
+            _theme(context).onVolumeChanged != null));
+
     var seekOnDoubleTapEnabledWhileControlsAreVisible =
         (_theme(context).seekOnDoubleTap &&
             _theme(context).seekOnDoubleTapEnabledWhileControlsVisible);
@@ -940,18 +943,9 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                                     if (position.dx <=
                                         widgetWidth(context) / 2) {
                                       // Left side of screen swiped
-                                      if ((!mount &&
-                                              _theme(context)
-                                                  .brightnessGesture &&
-                                              _theme(context)
-                                                      .onBrightnessChanged !=
-                                                  null) ||
-                                          (_theme(context).brightnessGesture &&
-                                              _theme(context)
-                                                  .gesturesEnabledWhileControlsVisible &&
-                                              _theme(context)
-                                                      .onBrightnessChanged !=
-                                                  null)) {
+                                      if ((!mount) ||
+                                          (_theme(context)
+                                              .gesturesEnabledWhileControlsVisible)) {
                                         final brightness = _brightnessValue -
                                             delta /
                                                 _theme(context)
@@ -963,15 +957,9 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                                     } else {
                                       // Right side of screen swiped
 
-                                      if ((!mount &&
-                                              _theme(context).volumeGesture &&
-                                              _theme(context).onVolumeChanged !=
-                                                  null) ||
-                                          (_theme(context).volumeGesture &&
-                                              _theme(context)
-                                                  .gesturesEnabledWhileControlsVisible &&
-                                              _theme(context).onVolumeChanged !=
-                                                  null)) {
+                                      if ((!mount) ||
+                                          (_theme(context)
+                                              .gesturesEnabledWhileControlsVisible)) {
                                         final volume = _volumeValue -
                                             delta /
                                                 _theme(context)

--- a/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
+++ b/media_kit_video/lib/media_kit_video_controls/src/controls/material.dart
@@ -829,6 +829,8 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
 
   @override
   Widget build(BuildContext context) {
+    final verticalGesturesEnabled =
+        (_theme(context).brightnessGesture || (_theme(context).volumeGesture));
     var seekOnDoubleTapEnabledWhileControlsAreVisible =
         (_theme(context).seekOnDoubleTap &&
             _theme(context).seekOnDoubleTapEnabledWhileControlsVisible);
@@ -930,49 +932,56 @@ class _MaterialVideoControlsState extends State<_MaterialVideoControls> {
                             onHorizontalDragEnd: (details) {
                               onHorizontalDragEnd();
                             },
-                            onVerticalDragUpdate: (e) async {
-                              final delta = e.delta.dy;
-                              final Offset position = e.localPosition;
+                            onVerticalDragUpdate: verticalGesturesEnabled
+                                ? (e) async {
+                                    final delta = e.delta.dy;
+                                    final Offset position = e.localPosition;
 
-                              if (position.dx <= widgetWidth(context) / 2) {
-                                // Left side of screen swiped
-                                if ((!mount &&
-                                        _theme(context).brightnessGesture &&
-                                        _theme(context).onBrightnessChanged !=
-                                            null) ||
-                                    (_theme(context).brightnessGesture &&
-                                        _theme(context)
-                                            .gesturesEnabledWhileControlsVisible &&
-                                        _theme(context).onBrightnessChanged !=
-                                            null)) {
-                                  final brightness = _brightnessValue -
-                                      delta /
-                                          _theme(context)
-                                              .verticalGestureSensitivity;
-                                  final result = brightness.clamp(0.0, 1.0);
-                                  setBrightness(result);
-                                }
-                              } else {
-                                // Right side of screen swiped
+                                    if (position.dx <=
+                                        widgetWidth(context) / 2) {
+                                      // Left side of screen swiped
+                                      if ((!mount &&
+                                              _theme(context)
+                                                  .brightnessGesture &&
+                                              _theme(context)
+                                                      .onBrightnessChanged !=
+                                                  null) ||
+                                          (_theme(context).brightnessGesture &&
+                                              _theme(context)
+                                                  .gesturesEnabledWhileControlsVisible &&
+                                              _theme(context)
+                                                      .onBrightnessChanged !=
+                                                  null)) {
+                                        final brightness = _brightnessValue -
+                                            delta /
+                                                _theme(context)
+                                                    .verticalGestureSensitivity;
+                                        final result =
+                                            brightness.clamp(0.0, 1.0);
+                                        setBrightness(result);
+                                      }
+                                    } else {
+                                      // Right side of screen swiped
 
-                                if ((!mount &&
-                                        _theme(context).volumeGesture &&
-                                        _theme(context).onVolumeChanged !=
-                                            null) ||
-                                    (_theme(context).volumeGesture &&
-                                        _theme(context)
-                                            .gesturesEnabledWhileControlsVisible &&
-                                        _theme(context).onVolumeChanged !=
-                                            null)) {
-                                  final volume = _volumeValue -
-                                      delta /
-                                          _theme(context)
-                                              .verticalGestureSensitivity;
-                                  final result = volume.clamp(0.0, 1.0);
-                                  setVolume(result);
-                                }
-                              }
-                            },
+                                      if ((!mount &&
+                                              _theme(context).volumeGesture &&
+                                              _theme(context).onVolumeChanged !=
+                                                  null) ||
+                                          (_theme(context).volumeGesture &&
+                                              _theme(context)
+                                                  .gesturesEnabledWhileControlsVisible &&
+                                              _theme(context).onVolumeChanged !=
+                                                  null)) {
+                                        final volume = _volumeValue -
+                                            delta /
+                                                _theme(context)
+                                                    .verticalGestureSensitivity;
+                                        final result = volume.clamp(0.0, 1.0);
+                                        setVolume(result);
+                                      }
+                                    }
+                                  }
+                                : null,
                             child: Container(
                               color: const Color(0x00000000),
                             ),


### PR DESCRIPTION
BUG: If user tries to scroll while gesturing on a video player, the video player consumes the gesture even with volumeGesture = false and brightnessGesture = false.

- The video player has an onVerticalDrag() handler that does nothing and is empty if volumeGesture is set to false and brightnessGesture is set to false
- Instead of it being '() {}' and unnecessarily consuming the gesture, we set it to NULL.

This makes sure that if the vertical drag has no use, it doesn't take away the parent's scroll gesture.