### PR TITLE
fix: correct aspect ratio for rotated videos (#1143)

### DIFF
--- a/video_player_media_kit/lib/src/media_kit_video_player.dart
+++ b/video_player_media_kit/lib/src/media_kit_video_player.dart
@@ -257,8 +257,19 @@ class MediaKitVideoPlayer extends VideoPlayerPlatform {
       streamSubscriptions.add(
         player.stream.videoParams.listen(
           (event) {
-            width = event.dw;
-            height = event.dh;
+            // Check for rotation metadata
+            final rotate = event.rotate ?? 0;
+
+            // Swap dimensions for portrait-oriented videos stored as landscape
+            if (rotate == 90 || rotate == 270) {
+              width = event.dh;
+              height = event.dw;
+            } else {
+              width = event.dw;
+              height = event.dh;
+            }
+
+            // Notify the platform interface with corrected dimensions
             if ((width ?? 0) > 0 && (height ?? 0) > 0) {
               notify();
             }


### PR DESCRIPTION
issues : https://github.com/media-kit/media-kit/issues/1143

## Overview
This document describes the fix for incorrect orientation and aspect ratio detection in `MediaKitVideoPlayer`, specifically affecting rotated videos such as portrait recordings from iPhones.

## The Problem
Portrait videos captured on many mobile devices (especially iPhones) are often stored as landscape frames (e.g., 1920x1080) with a metadata flag indicating a 90 or 270-degree rotation. 

Prior to this fix, the `VideoPlayerPlatform` implementation only utilized the raw display dimensions (`dw` and `dh`) from the `VideoParams` event, ignoring the `rotate` metadata. This resulted in:
1. The Flutter `video_player` plugin receiving incorrect dimensions (landscape instead of portrait).
2. The UI creating a landscape `AspectRatio` container.
3. The video appearing "shrunk" or "pillarboxed" incorrectly within the UI because the actual rendered content was vertical.

## The Solution
The implementation was updated to interpret the `rotate` property provided by `media_kit`. If the video is rotated by 90 or 270 degrees, the width and height are swapped before being emitted via the `VideoEvent.initialized` event.

