### PR TITLE
fix(ci): fix player-seek-after-completed test on Linux

### DIFF
--- a/media_kit/test/src/player/player_test.dart
+++ b/media_kit/test/src/player/player_test.dart
@@ -1065,6 +1065,9 @@ void main() {
       // Wait for EOF.
       await completer.future;
 
+      // NOTE: VOLUNTARY DELAY.
+      await Future.delayed(const Duration(seconds: 5));
+
       final expectPosition = expectAsync1(
         (value) {
           print(value);
@@ -1080,9 +1083,6 @@ void main() {
         print(event);
         expectPosition(event);
       });
-
-      // NOTE: VOLUNTARY DELAY.
-      await Future.delayed(const Duration(seconds: 5));
 
       // Begin test.
 


### PR DESCRIPTION
Fixes a flaky `player-seek-after-completed` test with newer mpv versions.

After EOF, the test now waits for trailing `time-pos` events to flush before subscribing to `position`, so it only validates the `Duration.zero` event emitted by `seek(Duration.zero)`.
