### PR TITLE
feat: add iosManageAudioSession option to PlayerConfiguration

### DIFF
--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -2332,6 +2332,10 @@ class NativePlayer extends PlatformPlayer {
         // Set --vid=no by default to prevent redundant video decoding.
         // [VideoController] internally sets --vid=auto upon attachment to enable video rendering & decoding.
         if (!test) 'vid': 'no',
+        // Skip mpv's AVAudioSession management when the embedder owns the
+        // session. iOS-specific.
+        if (Platform.isIOS && !configuration.iosManageAudioSession)
+          'audiounit-skip-session-management': 'yes',
       };
 
       if (Platform.isAndroid &&

--- a/media_kit/lib/src/player/platform_player.dart
+++ b/media_kit/lib/src/player/platform_player.dart
@@ -514,6 +514,23 @@ class PlayerConfiguration {
   /// Learn more: https://ffmpeg.org/ffmpeg-protocols.html#Protocol-Options
   final List<String> protocolWhitelist;
 
+  /// Whether [Player] should let mpv configure and activate the global
+  /// `AVAudioSession` on iOS.
+  ///
+  /// When `false`, the AudioUnit audio output skips `setCategory`,
+  /// `setActive:YES` on init, and `setActive:NO` on dispose — leaving the
+  /// session under the embedder's control.
+  ///
+  /// `AVAudioSession` is process-wide on iOS, so when more than one
+  /// component manages audio (e.g. another player or a custom coordinator),
+  /// only one of them should own the session — otherwise their category and
+  /// activation calls will conflict and cause playback issues.
+  ///
+  /// No effect on platforms other than iOS.
+  ///
+  /// Default: `true`.
+  final bool iosManageAudioSession;
+
   /// {@macro player_configuration}
   const PlayerConfiguration({
     this.vo = 'null',
@@ -539,6 +556,7 @@ class PlayerConfiguration {
       'https',
       'crypto',
     ],
+    this.iosManageAudioSession = true,
   });
 }
 


### PR DESCRIPTION
## Problem
On iOS, mpv's ao_audiounit driver unconditionally configures and activates the process-wide `AVAudioSession`:
  - on init it calls `setCategory:` and `setActive:YES`
  - on uninit it calls `setActive:NO`

`AVAudioSession` is shared across the whole app, so this fights any other component that needs to manage it — e.g. `audio_session`, `just_audio`, other instance of `media_kit` player. The most visible symptom is that disposing a Player deactivates the session, which silences whatever else was playing in the host app.

## Change
Adds an `iosManageAudioSession` flag to `PlayerConfiguration` (default: `true`, behavior unchanged). When set to `false`, media_kit forwards `audiounit-skip-session-management=yes` to libmpv, which short-circuits the session calls inside `ao_audiounit` — leaving `setCategory`, `setActive:YES`, and `setActive:NO` under the embedder's control.

```dart
final player = Player(
  configuration: const PlayerConfiguration(
    iosManageAudioSession: false, // embedder owns AVAudioSession
  ),
);
```

The flag has no effect on platforms other than iOS.

## Demo
A standalone reproduction with fix demonstration is here: https://github.com/IgorKhramtsov/media_kit_ios_audio_session_example
It runs `just_audio` alongside `media_kit`. Disposing the `media_kit` Player silences the `just_audio` track when `iosManageAudioSession: true`, and leaves it playing when `false`.

## Related artifact work
The `audiounit-skip-session-management` option is not part of upstream mpv. It is added by a small patch applied during the `libmpv` build.

- https://github.com/media-kit/libmpv-darwin-build/pull/52 — PR adding `mpv-audiounit-skip-session-management.patch`

Fixes
  - Fixes #1205
  - Fixes #1227
  - Fixes #964
