### PR TITLE
fix(windows): Fix Media.extras values always get deleted on windows

### DIFF
--- a/media_kit/lib/src/models/media/media_native.dart
+++ b/media_kit/lib/src/models/media/media_native.dart
@@ -168,7 +168,13 @@ class Media extends Playable {
     switch (parser.type) {
       case URIType.file:
         {
-          return parser.file!.path;
+          var path = parser.file!.path;
+          if (Platform.isWindows) {
+            path = path.replaceAll(RegExp(r'^[\/\\]+[\?\\]+[\/\\]+'), '');
+            path = path.replaceAll('/', '\\');
+            path = path.toLowerCase();
+          }
+          return path;
         }
       case URIType.network:
         {


### PR DESCRIPTION
Description
Fixes an issue on Windows where Media.extras metadata is lost whenever I do setShuffle.

Root Cause (According to Gemini)
During native playlist updates, the C++ bridge reconstructs Dart Media objects from raw paths. On Windows, these paths often contain backslash/forward slash mismatches or the extended path namespace prefix (e.g. //?/D:/Music/...). Because Media.normalizeURI doesn't standardize these Windows-specific path formats, the internal Media.cache lookup fails to resolve the original extras mapping.

Fix
Updated Media.normalizeURI under the URIType.file case for Windows to:

Strip Win32 namespace extended path prefixes (\\?\ or //?/).
Standardize all slashes to backslashes (\).
Convert the path to lowercase for case-insensitive lookup.