### PR TITLE
fix(android): close NativeCallable after mpv_terminate_destroy to prevent SIGABRT on Flutter 3.38+

### DIFF
--- a/media_kit/lib/src/player/native/core/initializer.dart
+++ b/media_kit/lib/src/player/native/core/initializer.dart
@@ -57,15 +57,19 @@ class Initializer {
   }
 
   /// Disposes [Pointer<mpv_handle>].
-  void dispose(Pointer<generated.mpv_handle> ctx) {
+  ///
+  /// Returns the [WakeUpNativeCallable] if one was used, so the caller can
+  /// close it after `mpv_terminate_destroy` has joined the mpv core thread.
+  WakeUpNativeCallable? dispose(Pointer<generated.mpv_handle> ctx) {
     if (kDebugMode && isMainIsolate()) {
       InitializerIsolate().dispose(mpv, ctx);
-      return;
+      return null;
     }
     if (!isExecmemRestricted) {
-      InitializerNativeCallable(mpv).dispose(ctx);
+      return InitializerNativeCallable(mpv).dispose(ctx);
     } else {
       InitializerIsolate().dispose(mpv, ctx);
+      return null;
     }
   }
 

--- a/media_kit/lib/src/player/native/core/initializer_native_callable.dart
+++ b/media_kit/lib/src/player/native/core/initializer_native_callable.dart
@@ -57,15 +57,21 @@ class InitializerNativeCallable {
   }
 
   /// Disposes [Pointer<mpv_handle>].
-  void dispose(Pointer<generated.mpv_handle> ctx) {
+  ///
+  /// Returns the [WakeUpNativeCallable] associated with [ctx] so the caller
+  /// can close it **after** `mpv_terminate_destroy` has joined the mpv core
+  /// thread. Closing the callable before that point risks a SIGABRT on
+  /// Flutter 3.38+ ("Callback invoked after it has been deleted").
+  WakeUpNativeCallable? dispose(Pointer<generated.mpv_handle> ctx) {
     _locks.remove(ctx.address);
     _eventCallbacks.remove(ctx.address);
 
-    // Clear the wakeup callback in libmpv before closing NativeCallable
-    // to prevent libmpv from invoking a deleted callback
+    // Clear the wakeup callback in libmpv so it stops *scheduling* new
+    // invocations, but do NOT close the NativeCallable yet — an in-flight
+    // wakeup on the mpv core thread may still land.
     mpv.mpv_set_wakeup_callback(ctx, nullptr, nullptr);
-    
-    _wakeUpNativeCallables.remove(ctx.address)?.close();
+
+    return _wakeUpNativeCallables.remove(ctx.address);
   }
 
   void _callback(Pointer<generated.mpv_handle> ctx) {

--- a/media_kit/lib/src/player/native/player/real.dart
+++ b/media_kit/lib/src/player/native/player/real.dart
@@ -110,10 +110,14 @@ class NativePlayer extends PlatformPlayer {
 
       await super.dispose();
 
-      Initializer(mpv).dispose(ctx);
+      final callable = Initializer(mpv).dispose(ctx);
 
       Future.delayed(const Duration(seconds: 5), () {
         mpv.mpv_terminate_destroy(ctx);
+        // Close the NativeCallable only after mpv_terminate_destroy has
+        // synchronously joined the mpv core thread. At this point no
+        // wakeup can ever fire again, so the trampoline is safe to tear down.
+        callable?.close();
       });
     }
 


### PR DESCRIPTION
Flutter 3.38+ changed the Dart VM behavior so that invoking a `NativeCallable` after `.close()` aborts the process (SIGABRT, "Callback invoked after it has been deleted", frame `DLRT_GetFfiCallbackMetadata` in `libflutter.so`). This change exposed a pre-existing sequencing race condition in media_kit's disposal routine.

### Root Cause
Previously, `NativePlayer.dispose()` followed this sequence:
1. `Initializer(mpv).dispose(ctx)` -> immediately cleared the wakeup callback and closed the `NativeCallable`.
2. `Future.delayed(Duration(seconds: 5), ...)` -> destroyed the context via `mpv_terminate_destroy(ctx)`.

Although `mpv_set_wakeup_callback(ctx, nullptr, nullptr)` posts a null replacement, it does not wait for in-flight wakeup invocations to finish on the mpv core thread, which remains alive for the 5-second window. If mpv fires a wakeup callback during this window, it hits the already-closed `NativeCallable` trampoline, crashing the process.

Conversely, `mpv_terminate_destroy` synchronously joins the mpv core thread. Once it returns, no more wakeups can fire. Thus, the `NativeCallable` must be closed AFTER `mpv_terminate_destroy`, not before.

### Solution
1. **`lib/src/player/native/core/initializer_native_callable.dart`**:
   - Modified `dispose()` signature to return `WakeUpNativeCallable?`.
   - Removed `.close()` from the method and returned the removed callable instead.
2. **`lib/src/player/native/core/initializer.dart`**:
   - Threaded the returned nullable callable back to the caller.
3. **`lib/src/player/native/player/real.dart`**:
   - Updated `NativePlayer.dispose()` to capture the returned callable.
   - Defer closing the callable until inside the delayed future, immediately after `mpv_terminate_destroy(ctx)` runs and joins the mpv thread.

This is the production-release counterpart of PR #1352 (which resolved hot-restarts in debug mode but left this production race open).

Fixes: #1340, #1397
